### PR TITLE
Support port config for postgres

### DIFF
--- a/include/db/pdo-postgres.inc.php
+++ b/include/db/pdo-postgres.inc.php
@@ -49,10 +49,21 @@ function serendipity_db_in_sql($col, &$search_ids, $type = ' OR ') {
 function serendipity_db_connect() {
     global $serendipity;
 
+    $host = $port = '';
+    if (strlen($serendipity['dbHost'])) {
+        if (false !== strstr($serendipity['dbHost'], ':')) {
+            $tmp = explode(':', $serendipity['dbHost']);
+            $host = "host={$tmp[0]};";
+            $port = "port={$tmp[1]};";
+        } else {
+            $host = "host={$serendipity['dbHost']};";
+        }
+    }
+
     $serendipity['dbConn'] = new PDO(
                                sprintf(
                                  'pgsql:%sdbname=%s',
-                                 strlen($serendipity['dbHost']) ? ('host=' . $serendipity['dbHost'] . ';') : '',
+                                 "$host$port",
                                  $serendipity['dbName']
                                ),
                                $serendipity['dbUser'],

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -53,10 +53,22 @@ function serendipity_db_connect() {
         $function = 'pg_connect';
     }
 
+    $host = $port = '';
+    if (strlen($serendipity['dbHost'])) {
+        if (false !== strstr($serendipity['dbHost'], ':')) {
+            $tmp = explode(':', $serendipity['dbHost']);
+            $host = "host={$tmp[0]} ";
+            $port = "port={$tmp[1]} ";
+        } else {
+            $host = "host={$serendipity['dbHost']} ";
+        }
+    }
+
+
     $serendipity['dbConn'] = $function(
                                sprintf(
                                  '%sdbname=%s user=%s password=%s',
-                                 strlen($serendipity['dbHost']) ? ('host=' . $serendipity['dbHost'] . ' ') : '',
+                                 "$host$port",
                                  $serendipity['dbName'],
                                  $serendipity['dbUser'],
                                  $serendipity['dbPass']


### PR DESCRIPTION
This can be useful for using proxies like pgpool or just if the server runs on a non standard port.
