### PR TITLE
Set focus on input field when logging in.

### DIFF
--- a/templates/2k11/admin/index.tpl
+++ b/templates/2k11/admin/index.tpl
@@ -62,6 +62,9 @@
                 </fieldset>
                 {$admin_vars.out.table}
             </form>
+            <script type="text/javascript">
+                document.forms.login.login_uid.focus()
+            </script>
             {$admin_vars.out.footer}
     {else}
         {if NOT $admin_vars.no_sidebar}


### PR DESCRIPTION
Add some js to set the focus on the input form when logging in to the backend so you can type ahead with your user name without needing to click on the input field.
