### PR TITLE
Really fix concatenation of entry body for full feed

### DIFF
--- a/include/functions_rss.inc.php
+++ b/include/functions_rss.inc.php
@@ -68,7 +68,7 @@ function serendipity_printEntries_rss(&$entries, $version, $comments = false, $f
 
             // Embed a link to extended entry, if existing
             if ($options['fullFeed']) {
-                $entry['body'] .= '\n' . $entry['extended'];
+                $entry['body'] .= "\n" . $entry['extended'];
                 $ext = '';
             } elseif ($entry['exflag']) {
                 $ext = '<a class="block_level" href="' . $entry['feed_entryLink'] . '#extended">' . sprintf(VIEW_EXTENDED_ENTRY, serendipity_specialchars($entry['title'])) . '</a>';


### PR DESCRIPTION
Commit 70c4ce8e406a6a3088f0f2485a9af21c68033589 will need double quotes around \n ...

See #335 for context.