### PR TITLE
Fix column quotes for INSERT statement

### DIFF
--- a/include/functions_upgrader.inc.php
+++ b/include/functions_upgrader.inc.php
@@ -430,7 +430,7 @@ function serendipity_upgrader_move_syndication_config() {
         if (is_array($value)) {
             $value = $value[0];
         }
-        serendipity_db_query("INSERT INTO {$serendipity['dbPrefix']}config('name', 'value') VALUES ('$newGeneralOption', '". serendipity_db_escape_string($value) ."')");
+        serendipity_db_query("INSERT INTO {$serendipity['dbPrefix']}config(name, value) VALUES ('$newGeneralOption', '". serendipity_db_escape_string($value) ."')");
     }
 
     $fbid = serendipity_db_query("SELECT value FROM {$serendipity['dbPrefix']}config WHERE NAME LIKE 'serendipity_plugin_syndication%fb_id'");
@@ -438,7 +438,7 @@ function serendipity_upgrader_move_syndication_config() {
     if ($show_feedburner == "force") {
         if (! empty($fbid) ) {
             $fburl = 'http://feeds.feedburner.com/' . $fbid;
-            serendipity_db_query("INSERT INTO {$serendipity['dbPrefix']}config('name', 'value') VALUES ('feedCustom', '" . serendipity_db_escape_string($fburl) ."')");
+            serendipity_db_query("INSERT INTO {$serendipity['dbPrefix']}config(name, value) VALUES ('feedCustom', '" . serendipity_db_escape_string($fburl) ."')");
         }
     }
 }


### PR DESCRIPTION
I did an upgrade from 1.7 to 2.0.1 and it failed initially:

```
Uncaught exception 'ErrorException' with message 'pg_query(): Query failed: ERROR:  syntax error at or near &quot;'name'&quot;
LINE 1: INSERT INTO s9y_config('name', 'value') VALUES ('feedBannerU...,
```

I tracked it down to INSERT statements that use quotes around the column names. The migration worked after I removed the quotes.