### PR TITLE
additional space in TopExits/Referrers for better word-wrap

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -938,14 +938,14 @@ function serendipity_displayTopUrlList($list, $limit, $use_links = true, $interv
         foreach ($rows as $row) {
             if ($use_links) {
                 $output .= sprintf(
-                    '<span class="block_level"><a href="%1$s://%2$s" title="%2$s" >%2$s</a> (%3$s)</span>',
+                    '<span class="block_level"><a href="%1$s://%2$s" title="%2$s" >%2$s</a> (%3$s) </span>',
                     serendipity_specialchars($row['scheme']),
                     serendipity_specialchars($row['host']),
                     serendipity_specialchars($row['total'])
                 );
             } else {
                 $output .= sprintf(
-                    '<span class="block_level">%1$s (%2$s)</span>',
+                    '<span class="block_level">%1$s (%2$s) </span>',
                     serendipity_specialchars($row['host']),
                     serendipity_specialchars($row['total'])
                 );


### PR DESCRIPTION
There was no space between total value and next host, so display,
depending on available width, was

www.example1.com (12)www.example2.com
(23)www.example3.com (34)

With an additional trailing space after total it is

www.example1.com (12)
www.example2.com (23)
www.example3.com (34)