### PR TITLE
Disable email notifications for replies send from backend

### DIFF
--- a/include/admin/comments.inc.php
+++ b/include/admin/comments.inc.php
@@ -56,6 +56,7 @@ if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminActio
     $comment['email']     = $serendipity['POST']['email'];
     $comment['subscribe'] = $serendipity['POST']['subscribe'];
     $comment['parent_id'] = $serendipity['POST']['replyTo'];
+    $comment['backend']   = true;
     if (!empty($comment['comment'])) {
         if (serendipity_saveComment($serendipity['POST']['entry_id'], $comment, 'NORMAL')) {
             $data['commentReplied'] = true;

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -801,6 +801,7 @@ function serendipity_insertComment($id, $commentInfo, $type = 'NORMAL', $source 
     $status        = serendipity_db_escape_string(isset($commentInfo['status']) ? $commentInfo['status'] : (serendipity_db_bool($ca['moderate_comments']) ? 'pending' : 'approved'));
     $t             = serendipity_db_escape_string(isset($commentInfo['time']) ? $commentInfo['time'] : time());
     $referer       = substr((isset($_SESSION['HTTP_REFERER']) ? serendipity_db_escape_string($_SESSION['HTTP_REFERER']) : ''), 0, 200);
+    $backend       = $commentInfo['backend'];
 
     $query = "SELECT a.email, e.title, a.mail_comments, a.mail_trackbacks
                 FROM {$serendipity['dbPrefix']}entries AS e
@@ -873,7 +874,9 @@ function serendipity_insertComment($id, $commentInfo, $type = 'NORMAL', $source 
     if ($status != 'confirm' && (serendipity_db_bool($ca['moderate_comments'])
         || ($type == 'NORMAL' && serendipity_db_bool($row['mail_comments']))
         || (($type == 'TRACKBACK' || $type == 'PINGBACK') && serendipity_db_bool($row['mail_trackbacks'])))) {
-        serendipity_sendComment($cid, $row['email'], $name, $email, $url, $id, $row['title'], $comments, $type, serendipity_db_bool($ca['moderate_comments']), $referer);
+            if(!$backend){
+                serendipity_sendComment($cid, $row['email'], $name, $email, $url, $id, $row['title'], $comments, $type, serendipity_db_bool($ca['moderate_comments']), $referer);
+            }
     }
 
     // Approve with force, if moderation is disabled

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -874,7 +874,7 @@ function serendipity_insertComment($id, $commentInfo, $type = 'NORMAL', $source 
     if ($status != 'confirm' && (serendipity_db_bool($ca['moderate_comments'])
         || ($type == 'NORMAL' && serendipity_db_bool($row['mail_comments']))
         || (($type == 'TRACKBACK' || $type == 'PINGBACK') && serendipity_db_bool($row['mail_trackbacks'])))) {
-            if(!$backend && $email == $row['email']){
+            if(!$backend && $email != $row['email']){
                 serendipity_sendComment($cid, $row['email'], $name, $email, $url, $id, $row['title'], $comments, $type, serendipity_db_bool($ca['moderate_comments']), $referer);
             }
     }

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -874,7 +874,7 @@ function serendipity_insertComment($id, $commentInfo, $type = 'NORMAL', $source 
     if ($status != 'confirm' && (serendipity_db_bool($ca['moderate_comments'])
         || ($type == 'NORMAL' && serendipity_db_bool($row['mail_comments']))
         || (($type == 'TRACKBACK' || $type == 'PINGBACK') && serendipity_db_bool($row['mail_trackbacks'])))) {
-            if(!$backend){
+            if(!$backend && $email == $row['email']){
                 serendipity_sendComment($cid, $row['email'], $name, $email, $url, $id, $row['title'], $comments, $type, serendipity_db_bool($ca['moderate_comments']), $referer);
             }
     }

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -874,7 +874,7 @@ function serendipity_insertComment($id, $commentInfo, $type = 'NORMAL', $source 
     if ($status != 'confirm' && (serendipity_db_bool($ca['moderate_comments'])
         || ($type == 'NORMAL' && serendipity_db_bool($row['mail_comments']))
         || (($type == 'TRACKBACK' || $type == 'PINGBACK') && serendipity_db_bool($row['mail_trackbacks'])))) {
-            if(!$backend && $email != $row['email']){
+            if (! ($backend && $email == $row['email'])) {
                 serendipity_sendComment($cid, $row['email'], $name, $email, $url, $id, $row['title'], $comments, $type, serendipity_db_bool($ca['moderate_comments']), $referer);
             }
     }


### PR DESCRIPTION
Hi,
this problem was discussed with onli on s9y forum. Every time if an author or admin reply to an comment from the backend, he receives an notification email. I would like to disable this behavior because the author knows that he has send a reply and don't require a notification for this topic.

Thanks a lot