### PR TITLE
Provide authenticated userdata for frotend comment form 

### DIFF
--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -1227,8 +1227,15 @@ function serendipity_printEntries($entries, $extended = 0, $preview = false, $sm
                     'is_comment_moderate'   => (isset($serendipity['GET']['csuccess']) && $serendipity['GET']['csuccess'] == 'moderate' ? true: false)
                 );
                 
+                if ($serendipity['serendipityAuthedUser'] === true) {
+                    $userData = array();
+                    $userData['name'] = $serendipity['realname'];
+                    $userData['email'] = $serendipity['email'];
+                    $userData['url'] = '';
+                } else {
+                    $userData = $serendipity['POST'];
+                }
                 
-
                 $serendipity['smarty']->assign($comment_add_data);
                 serendipity_displayCommentForm(
                     $entry['id'],

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -1226,13 +1226,22 @@ function serendipity_printEntries($entries, $extended = 0, $preview = false, $sm
                     'is_comment_added'      => (isset($serendipity['GET']['csuccess']) && $serendipity['GET']['csuccess'] == 'true' ? true: false),
                     'is_comment_moderate'   => (isset($serendipity['GET']['csuccess']) && $serendipity['GET']['csuccess'] == 'moderate' ? true: false)
                 );
+                
+                if ($serendipity['serendipityAuthedUser'] === true) {
+					$userData = array();
+		        	$userData['name'] = $serendipity['realname'];
+		        	$userData['email'] = $serendipity['email'];
+					$userData['url'] = '';
+				} else {
+					$userData = $serendipity['POST'];
+				}
 
                 $serendipity['smarty']->assign($comment_add_data);
                 serendipity_displayCommentForm(
                     $entry['id'],
                     $serendipity['serendipityHTTPPath'] . $serendipity['indexFile'] . '?url=' . $entry['commURL'],
                     true,
-                    $serendipity['POST'],
+                    $userData,
                     true,
                     serendipity_db_bool($entry['moderate_comments']),
                     $entry

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -1227,14 +1227,7 @@ function serendipity_printEntries($entries, $extended = 0, $preview = false, $sm
                     'is_comment_moderate'   => (isset($serendipity['GET']['csuccess']) && $serendipity['GET']['csuccess'] == 'moderate' ? true: false)
                 );
                 
-                if ($serendipity['serendipityAuthedUser'] === true) {
-					$userData = array();
-		        	$userData['name'] = $serendipity['realname'];
-		        	$userData['email'] = $serendipity['email'];
-					$userData['url'] = '';
-				} else {
-					$userData = $serendipity['POST'];
-				}
+                
 
                 $serendipity['smarty']->assign($comment_add_data);
                 serendipity_displayCommentForm(


### PR DESCRIPTION
Hi,
this patch will provide the email and realname of an authenticated user and commmit these values to commentform function. Now templates can pre-fill comment form with data from logged in users.