### PR TITLE
Show two "comments feed" buttons when both feed formats (RSS+Atom) activated

### DIFF
--- a/plugins/serendipity_plugin_syndication/serendipity_plugin_syndication.php
+++ b/plugins/serendipity_plugin_syndication/serendipity_plugin_syndication.php
@@ -203,10 +203,18 @@ class serendipity_plugin_syndication extends serendipity_plugin {
         }
 
         if (serendipity_db_bool($this->get_config('show_2.0c', false)) || serendipity_db_bool($this->get_config('show_comment_feed', false))) {
-            echo $this->generateFeedButton(($useAtom && ! $useRss ? serendipity_rewriteURL(PATH_FEEDS .'/comments.atom') : serendipity_rewriteURL(PATH_FEEDS .'/comments.rss2')),
-                                            $COMMENTS,
-                                            ($subtome ? $this->getOnclick(serendipity_rewriteURL(PATH_FEEDS .'/comments.rss2')) : ""),
-                                            $small_icon);
+            if ($useRss) {
+                echo $this->generateFeedButton( serendipity_rewriteURL(PATH_FEEDS .'/comments.rss2'),
+                                                $COMMENTS . ($useAtom ? " (RSS)": ""),
+                                                ($subtome ? $this->getOnclick(serendipity_rewriteURL(PATH_FEEDS .'/comments.rss2')) : ""),
+                                                $small_icon);
+            }
+            if ($useAtom) {
+                echo $this->generateFeedButton( serendipity_rewriteURL(PATH_FEEDS .'/comments.atom10'),
+                                                $COMMENTS . ($useRss ? " (Atom)": ""),
+                                                ($subtome ? $this->getOnclick(serendipity_rewriteURL(PATH_FEEDS .'/comments.atom10')) : ""),
+                                                $small_icon);
+            }
         }
         echo "</ul>\n";
     }


### PR DESCRIPTION
Show two "comments feed" buttons when both feed formats (RSS+Atom) activated and "subToMe" button disabled.

Sidebar before:
RSS Feed
Atom Feed
Comments

Sidebar now:
RSS Feed
Atom Feed
Comments (RSS)
Comments (Atom)

When only one format activated "comments" button shows without format name, for ex:
RSS Feed
Comments

----

Apologies for troubles in previous request

I really don't know how atom popular or not. My aggregator supports both RSS and Atom. This patch just makes plugin more whole and completes some functionality which wasn't fully implemented.
