### PR TITLE
HTTP500: crashing when username is an array

### DIFF
--- a/include/functions_config.inc.php
+++ b/include/functions_config.inc.php
@@ -530,7 +530,7 @@ function serendipity_authenticate_author($username = '', $password = '', $is_has
     }
 
     if ($debug) fwrite($fp, date('Y-m-d H:i') . ' - Login username check:' . $username . "\n");
-    if ($username != '') {
+    if ($username != '' && is_string($username)) {
         if ($use_external) {
             serendipity_plugin_api::hook_event('backend_auth', $is_hashed, array('username' => $username, 'password' => $password));
         }

--- a/include/functions_config.inc.php
+++ b/include/functions_config.inc.php
@@ -530,7 +530,7 @@ function serendipity_authenticate_author($username = '', $password = '', $is_has
     }
 
     if ($debug) fwrite($fp, date('Y-m-d H:i') . ' - Login username check:' . $username . "\n");
-    if ($username != '' && is_string($username)) {
+    if (!empty($username) && is_string($username)) {
         if ($use_external) {
             serendipity_plugin_api::hook_event('backend_auth', $is_hashed, array('username' => $username, 'password' => $password));
         }


### PR DESCRIPTION
Similar to #444 and #445, the login functionality crashes when the handed in username is an array.

Error:
`PHP Fatal error:  Uncaught ErrorException: Warning: PDO::quote() expects parameter 1 to be string, array given in include/db/pdo-sqlite.inc.php:122`

Request: POST /serendipity_admin.php
Version: 2.1-rc1
Form-Input needed to break it: _serendipity[user][]_