### PR TITLE
Dashboard: show as many drafts as configured.

### DIFF
--- a/include/admin/overview.inc.php
+++ b/include/admin/overview.inc.php
@@ -104,7 +104,10 @@ $entries = serendipity_fetchEntries(
                      'e.timestamp >= ' . serendipity_serverOffsetHour() . $efilter
                    );
 
-$entriesAmount = count($entries);
+$entriesAmount = 0;
+if (is_array($entries)) {
+    $entriesAmount = count($entries);
+};
 if ($entriesAmount < (int)$serendipity['dashboardDraftLimit']) {
     // there is still space for drafts
     $drafts = serendipity_fetchEntries(


### PR DESCRIPTION
The dashboard will show up to $dashboardLimit future
entries; if the number of future entries is still
less than $dashboardDraftLimit, it will add drafts
up to $dashboardDraftLimit.

If there are _no_ future entries, $entries is no
array, but has a value of "1"; count($entries)
will then be one, too, so one draft less will
be shown.

Closes #465.

Signed-off-by: Thomas Hochstein <thh@inter.net>