### PR TITLE
Make backend page title order configurable.

### DIFF
--- a/serendipity_admin.php
+++ b/serendipity_admin.php
@@ -227,9 +227,10 @@ if ($ajax) {
         $admin_vars[$poll_admin_var] =& $$poll_admin_var;
     }
 
-    $admin_vars['out']       = array();
-    $admin_vars['no_create'] = $serendipity['no_create'];
-    $admin_vars['title']     = $admin_section;
+    $admin_vars['out']         = array();
+    $admin_vars['no_create']   = $serendipity['no_create'];
+    $admin_vars['title']       = $admin_section;
+    $admin_vars['title_first'] = $serendipity['title_first'];
 
     if ($serendipity['expose_s9y']) {
         $admin_vars['version_info'] = sprintf(ADMIN_FOOTER_POWERED_BY, $serendipity['versionInstalled'], phpversion());

--- a/templates/2k11/admin/index.tpl
+++ b/templates/2k11/admin/index.tpl
@@ -3,7 +3,11 @@
 <!--[if gt IE 8]><!--> <html class="no-js" dir="{$CONST.LANG_DIRECTION}" lang="{$lang}"> <!--<![endif]-->
 <head>
     <meta charset="{$CONST.LANG_CHARSET}">
-    <title>{if $admin_vars.title}{$admin_vars.title} | {/if}{$blogTitle} | {$CONST.SERENDIPITY_ADMIN_SUITE}</title>
+    {if $admin_vars.title_first == 'blogtitle'}
+        <title>{$blogTitle} | {if $admin_vars.title}{$admin_vars.title}{/if} | {$CONST.SERENDIPITY_ADMIN_SUITE}</title>
+    {else}
+        <title>{if $admin_vars.title}{$admin_vars.title} | {/if}{$blogTitle} | {$CONST.SERENDIPITY_ADMIN_SUITE}</title>
+    {/if}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{$head_link_stylesheet}">
 <!--[if lte IE 8]>


### PR DESCRIPTION
The default page title of backend pages is
"section | blog title | $admin". You can
now change the order to "blog title | section
 | $admin" by setting $serendipity['title_first']
to "blogtitle" in serendipity_config_local.inc.php

Closes #413

Signed-off-by: Thomas Hochstein <thh@inter.net>