### PR TITLE
Fix broken compat layer.

### DIFF
--- a/include/compat.inc.php
+++ b/include/compat.inc.php
@@ -518,9 +518,6 @@ if (function_exists('date_default_timezone_get')) {
  * native encoded strings containing umlauts. This wrapper should to be used in the core until PHP 5.6 fixes the bug.
  */
 function serendipity_specialchars($string, $flags = null, $encoding = LANG_CHARSET, $double_encode = true) {
-    if (!is_string($string)) {
-        return '';
-    }
     if ($flags == null) {
         if (defined('ENT_HTML401')) {
             // Added with PHP 5.4.x
@@ -544,9 +541,6 @@ function serendipity_specialchars($string, $flags = null, $encoding = LANG_CHARS
  * see serendipity_specialchars
  */
 function serendipity_entities($string, $flags = null, $encoding = LANG_CHARSET, $double_encode = true) {
-    if (!is_string($string)) {
-        return '';
-    }
     if ($flags == null) {
         if (defined('ENT_HTML401')) {
             // Added with PHP 5.4.x
@@ -566,9 +560,6 @@ function serendipity_entities($string, $flags = null, $encoding = LANG_CHARSET, 
  * serendipity_specialchars
  */
 function serendipity_entity_decode($string, $flags = null, $encoding = LANG_CHARSET) {
-    if (!is_string($string)) {
-        return '';
-    }
     if ($flags == null) {
         # NOTE: ENT_SUBSTITUTE does not exist for this function, and the documentation does not specify that it will
         # ever echo empty strings on charset errors


### PR DESCRIPTION
Partially revert 7a0a9e215600284eb5aeea201d79563368f4c45b

serendipity_specialchars() and others were made to return "" when fed something that is not a string.
So boolean values (1 or TRUE) will be returned as "", i.e. FALSE, breaking the blog in interesting ways
(i.e. displaying wrong configuration values and saving them to the database).

Closes #476.

Signed-off-by: Thomas Hochstein <thh@inter.net>