### PR TITLE
Redo backend page title order.

### DIFF
--- a/serendipity_admin.php
+++ b/serendipity_admin.php
@@ -230,7 +230,7 @@ if ($ajax) {
     $admin_vars['out']         = array();
     $admin_vars['no_create']   = $serendipity['no_create'];
     $admin_vars['title']       = $admin_section;
-    $admin_vars['title_first'] = $serendipity['title_first'];
+    $admin_vars['backendBlogtitleFirst'] = $serendipity['backendBlogtitleFirst'];
 
     if ($serendipity['expose_s9y']) {
         $admin_vars['version_info'] = sprintf(ADMIN_FOOTER_POWERED_BY, $serendipity['versionInstalled'], phpversion());

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -137,6 +137,13 @@ if (!isset($serendipity['template_backend'])) {
     $serendipity['template_backend'] = '2k11';
 }
 
+// The default page title of backend pages is "section | blog title | SERENDIPITY_ADMIN_SUITE"
+// If set to true (in serendipity_config_local.inc.php), the page title will be
+// "blog title | section | SERENDIPITY_ADMIN_SUITE" instead
+if (!isset($serendipity['backendBlogtitleFirst'])) {
+    $serendipity['backendBlogtitleFirst'] = false;
+}
+
 // Available languages
 if (!isset($serendipity['languages'])) {
     $serendipity['languages'] = array('en' => 'English',

--- a/templates/2k11/admin/index.tpl
+++ b/templates/2k11/admin/index.tpl
@@ -3,10 +3,10 @@
 <!--[if gt IE 8]><!--> <html class="no-js" dir="{$CONST.LANG_DIRECTION}" lang="{$lang}"> <!--<![endif]-->
 <head>
     <meta charset="{$CONST.LANG_CHARSET}">
-    {if $admin_vars.title_first == 'blogtitle'}
-        <title>{$blogTitle} | {if $admin_vars.title}{$admin_vars.title}{/if} | {$CONST.SERENDIPITY_ADMIN_SUITE}</title>
-    {else}
+    {if !$admin_vars.backendBlogtitleFirst}
         <title>{if $admin_vars.title}{$admin_vars.title} | {/if}{$blogTitle} | {$CONST.SERENDIPITY_ADMIN_SUITE}</title>
+    {else}
+        <title>{$blogTitle} | {if $admin_vars.title}{$admin_vars.title}{/if} | {$CONST.SERENDIPITY_ADMIN_SUITE}</title>
     {/if}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{$head_link_stylesheet}">


### PR DESCRIPTION
Code style improvements from the reviews of #480 

* Rename ´$serendipity['title_first'´] to  ´$serendipity['backendBlogtitleFirst']´ and make it boolean

* Add default to `serendipity_config.inc.php`.

* Change the condition in ´2k11/admin/index.tpl´   that the first branch is run by default

Signed-off-by: Thomas Hochstein <thh@inter.net>