### PR TITLE
Dashboard: redo display of drafts / future entries 

### DIFF
--- a/include/admin/overview.inc.php
+++ b/include/admin/overview.inc.php
@@ -56,11 +56,8 @@ $data['updateButton'] = $output;
 if (!isset($serendipity['dashboardCommentsLimit'])) {
     $serendipity['dashboardCommentsLimit'] = 5;
 }
-if (!isset($serendipity['dashboardLimit'])) {
-    $serendipity['dashboardLimit'] = 5;
-}
-if (!isset($serendipity['dashboardDraftLimit'])) {
-    $serendipity['dashboardDraftLimit'] = 5;
+if (!isset($serendipity['dashboardEntriesLimit'])) {
+    $serendipity['dashboardEntriesLimit'] = 5;
 }
 
 $cjoin  = ($serendipity['serendipityUserlevel'] == USERLEVEL_EDITOR) ? "
@@ -97,7 +94,7 @@ $efilter = ($serendipity['serendipityUserlevel'] == USERLEVEL_EDITOR) ? ' AND e.
 $entries = serendipity_fetchEntries(
                      false,
                      false,
-                     (int)$serendipity['dashboardLimit'],
+                     (int)$serendipity['dashboardEntriesLimit'],
                      true,
                      false,
                      'timestamp DESC',
@@ -108,12 +105,12 @@ $entriesAmount = 0;
 if (is_array($entries)) {
     $entriesAmount = count($entries);
 };
-if ($entriesAmount < (int)$serendipity['dashboardDraftLimit']) {
+if ($entriesAmount < (int)$serendipity['dashboardEntriesLimit']) {
     // there is still space for drafts
     $drafts = serendipity_fetchEntries(
                      false,
                      false,
-                     (int)$serendipity['dashboardDraftLimit'] - $entriesAmount,
+                     (int)$serendipity['dashboardEntriesLimit'] - $entriesAmount,
                      true,
                      false,
                      'timestamp DESC',

--- a/include/admin/overview.inc.php
+++ b/include/admin/overview.inc.php
@@ -52,14 +52,6 @@ $data['update']       = version_compare($data['usedVersion'], $data['curVersion'
 serendipity_plugin_api::hook_event('plugin_dashboard_updater', $output, $data['curVersion']);
 $data['updateButton'] = $output;
 
-// Can be set through serendipity_config_local.inc.php
-if (!isset($serendipity['dashboardCommentsLimit'])) {
-    $serendipity['dashboardCommentsLimit'] = 5;
-}
-if (!isset($serendipity['dashboardEntriesLimit'])) {
-    $serendipity['dashboardEntriesLimit'] = 5;
-}
-
 $cjoin  = ($serendipity['serendipityUserlevel'] == USERLEVEL_EDITOR) ? "
         LEFT JOIN {$serendipity['dbPrefix']}authors a ON (e.authorid = a.authorid)
             WHERE e.authorid = " . (int)$serendipity['authorid']

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -144,6 +144,15 @@ if (!isset($serendipity['backendBlogtitleFirst'])) {
     $serendipity['backendBlogtitleFirst'] = false;
 }
 
+// Dashboard: set number of comments and drafts / future entries to be shown
+if (!isset($serendipity['dashboardCommentsLimit'])) {
+    $serendipity['dashboardCommentsLimit'] = 5;
+}
+
+if (!isset($serendipity['dashboardEntriesLimit'])) {
+    $serendipity['dashboardEntriesLimit'] = 5;
+}
+
 // Available languages
 if (!isset($serendipity['languages'])) {
     $serendipity['languages'] = array('en' => 'English',


### PR DESCRIPTION
See #488 for the discussion.

* Merge `dashboardLimit` and `dashboardDraftLimit` to `dashboardEntriesLimit`
* Move defaults to `serendipity_config.inc.php`

Signed-off-by: Thomas Hochstein <thh@inter.net>