### PR TITLE
Fix display of messages for comment editing.

### DIFF
--- a/include/admin/comments.inc.php
+++ b/include/admin/comments.inc.php
@@ -9,23 +9,23 @@ $data = array();
 $commentsPerPage = (int)(!empty($serendipity['GET']['filter']['perpage']) ? $serendipity['GET']['filter']['perpage'] : 10);
 $summaryLength = 200;
 
-$errormsg = '';
-$msg = '';
+$errormsg = array();
+$msg = array();
 
 if ($serendipity['POST']['formAction'] == 'multiDelete' && sizeof($serendipity['POST']['delete']) != 0 && serendipity_checkFormToken()) {
     if ($serendipity['POST']['togglemoderate'] != '') {
         foreach ( $serendipity['POST']['delete'] as $k => $v ) {
             $ac = serendipity_approveComment((int)$k, (int)$v, false, 'flip');
             if ($ac > 0) {
-                $msg .= DONE . ': '. sprintf(COMMENT_APPROVED, (int)$k);
+                $msg[] = DONE . ': '. sprintf(COMMENT_APPROVED, (int)$k);
             } else {
-                $msg .= DONE . ': '. sprintf(COMMENT_MODERATED, (int)$k);
+                $msg[] = DONE . ': '. sprintf(COMMENT_MODERATED, (int)$k);
             }
         }
     } else {
         foreach ( $serendipity['POST']['delete'] as $k => $v ) {
             serendipity_deleteComment($k, $v);
-            $msg .= DONE . ': '. sprintf(COMMENT_DELETED, (int)$k);
+            $msg[] = DONE . ': '. sprintf(COMMENT_DELETED, (int)$k);
         }
     }
 }
@@ -44,7 +44,7 @@ if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminActio
                   entry_id = " . (int)$serendipity['POST']['entry_id'];
     serendipity_db_query($sql);
     serendipity_plugin_api::hook_event('backend_updatecomment', $serendipity['POST'], $serendipity['GET']['id']);
-    $msg .= COMMENT_EDITED;
+    $msg[] = COMMENT_EDITED;
 }
 
 /* Submit a new comment */
@@ -63,11 +63,11 @@ if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminActio
             echo serendipity_smarty_show('admin/comments.inc.tpl', $data);
             return true;
         } else {
-            $errormsg .= COMMENT_NOT_ADDED;
+            $errormsg[] = COMMENT_NOT_ADDED;
             $serendipity['GET']['adminAction'] = 'reply';
         }
     } else {
-        $errormsg .= COMMENT_NOT_ADDED;
+        $errormsg[] = COMMENT_NOT_ADDED;
         $serendipity['GET']['adminAction'] = 'reply';
     }
 }
@@ -82,10 +82,10 @@ if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminActio
     $rs  = serendipity_db_query($sql, true);
 
     if ($rs === false) {
-        $errormsg .= ERROR .': '. sprintf(COMMENT_ALREADY_APPROVED, (int)$serendipity['GET']['id']);
+        $errormsg[] = ERROR .': '. sprintf(COMMENT_ALREADY_APPROVED, (int)$serendipity['GET']['id']);
     } else {
         serendipity_approveComment((int)$serendipity['GET']['id'], (int)$rs['entry_id']);
-        $msg .= DONE . ': '. sprintf(COMMENT_APPROVED, (int)$serendipity['GET']['id']);
+        $msg[] = DONE . ': '. sprintf(COMMENT_APPROVED, (int)$serendipity['GET']['id']);
     }
 }
 
@@ -98,17 +98,17 @@ if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminActio
     $rs  = serendipity_db_query($sql, true);
 
     if ($rs === false) {
-        $errormsg .= ERROR .': '. sprintf(COMMENT_ALREADY_APPROVED, (int)$serendipity['GET']['id']);
+        $errormsg[] = ERROR .': '. sprintf(COMMENT_ALREADY_APPROVED, (int)$serendipity['GET']['id']);
     } else {
         serendipity_approveComment((int)$serendipity['GET']['id'], (int)$rs['entry_id'], true, true);
-        $msg .= DONE . ': '. sprintf(COMMENT_MODERATED, (int)$serendipity['GET']['id']);
+        $msg[] = DONE . ': '. sprintf(COMMENT_MODERATED, (int)$serendipity['GET']['id']);
     }
 }
 
 /* We are asked to delete a comment */
 if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminAction'] == 'delete' && serendipity_checkFormToken()) {
     serendipity_deleteComment($serendipity['GET']['id'], $serendipity['GET']['entry_id']);
-    $msg .= DONE . ': '. sprintf(COMMENT_DELETED, (int)$serendipity['GET']['id']);
+    $msg[] = DONE . ': '. sprintf(COMMENT_DELETED, (int)$serendipity['GET']['id']);
 }
 
 /* We are either in edit mode, or preview mode */

--- a/templates/2k11/admin/comments.inc.tpl
+++ b/templates/2k11/admin/comments.inc.tpl
@@ -1,8 +1,12 @@
 {if !empty($errormsg)}
-    <span class="msg_error"><span class="icon-attention" aria-hidden="true"></span> {$errormsg}</span>
+    {foreach $errormsg as $show_errormsg}
+        <span class="msg_error"><span class="icon-attention" aria-hidden="true"></span> {$show_errormsg}</span>
+    {/foreach}
 {/if}
 {if !empty($msg)}
-    <span class="msg_notice"><span class="icon-info-circled" aria-hidden="true"></span> {$msg}</span>
+    {foreach $msg as $show_msg}
+        <span class="msg_notice"><span class="icon-info-circled" aria-hidden="true"></span> {$show_msg}</span>
+    {/foreach}
 {/if}
 {if $commentReplied}
     <span class="msg_success"><span class="icon-ok-circled" aria-hidden="true"></span> {$CONST.COMMENT_ADDED}</span>


### PR DESCRIPTION
All messages and errors were appended to $msg and $errormsg, respectively, creating one long unformatted string - mostly unreadable.

So we make $msg and $errormsg arrays instead and iterate over those arrays in the template, displaying each message separately.

Fixes #525.

Signed-off-by: Thomas Hochstein <thh@inter.net>