### PR TITLE
added iframe to allowed singleton tags

### DIFF
--- a/plugins/serendipity_event_nl2br/serendipity_event_nl2br.php
+++ b/plugins/serendipity_event_nl2br/serendipity_event_nl2br.php
@@ -411,7 +411,7 @@ p.break {
 	
 	var $singleton_elements = array('area', 'br', 'col', 'command', 'embed', 'hr', 
 								'img', 'input', 'keygen', 'link', 'param', 'source', 
-								'track', 'wbr', '!--' 
+								'track', 'wbr', '!--', 'iframe' 
 								);
 
 	var $allowed_p_parents = array('blockquote', 'td', 'div', 'article', 'aside', 'dd',


### PR DESCRIPTION
Found a small bug: iframe tag was not in the allowed tags, so an embedded YouTube video wouldn't work.