### PR TITLE
Another fix to Spartacus after dropping netmirror.

### DIFF
--- a/plugins/serendipity_event_spartacus/ChangeLog
+++ b/plugins/serendipity_event_spartacus/ChangeLog
@@ -1,3 +1,11 @@
+2.37.5:
+-------
+    * Fix missing reset to default after dropping netmirror.
+
+2.37.4:
+-------
+    * Drop netmirror, set mirror to default if it was set to netmirror.
+
 2.37.3:
 -------
     * Change mirror order (new default: github)

--- a/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
+++ b/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
@@ -27,7 +27,7 @@ class serendipity_event_spartacus extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_SPARTACUS_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking');
-        $propbag->add('version',       '2.37.4');
+        $propbag->add('version',       '2.37.5');
         $propbag->add('requirements',  array(
             'serendipity' => '1.6',
         ));
@@ -839,6 +839,9 @@ class serendipity_event_spartacus extends serendipity_event
 
         $mirrors = $this->getMirrors('files', true);
         $mirror  = $mirrors[$this->get_config('mirror_files', 0)];
+        if ($mirror == null) {
+            $mirror = $mirrors[0];
+        }
 
         $custom  = $this->get_config('custommirror');
         if (strlen($custom) > 2) {
@@ -1002,9 +1005,9 @@ class serendipity_event_spartacus extends serendipity_event
 
         $mirrors = $this->getMirrors('files', true);
         $mirror  = $mirrors[$this->get_config('mirror_files', 0)];
-	if ($mirror == null) {
-		$mirror = $mirrors[0];
-	}
+        if ($mirror == null) {
+            $mirror = $mirrors[0];
+        }
         $custom  = $this->get_config('custommirror');
         if (strlen($custom) > 2) {
             $servers = explode('|', $custom);


### PR DESCRIPTION
See #548.

Expands b0fb8d2d126bc8c6e2745c466eb5429c18615738
by adding the necessary fix at another code point.

Fixes a whitespace issue (tabs -> spaces).

Add Changelog entries.

Needs to be backported to 2.1 after tests and review.

Signed-off-by: Thomas Hochstein <thh@inter.net>