### PR TITLE
Return output

### DIFF
--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -842,6 +842,7 @@ class serendipity_event_spamblock extends serendipity_event
                 );
             }
             $output .= '</div>';
+            return $output;
         }
     }
 


### PR DESCRIPTION
When $use_gd is false, returning $output so that the captcha images that have been generated are actually embedded into the final rendering of the page.

Fixes #536.