### PR TITLE
Check NEWS, remove duplicate items.

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -17,8 +17,6 @@ Version 2.2.1-alpha1 (September 20th, 2018)
 
     * [Security] Improved password hashing by moving to bcrypt
 
-    * Fix links to the documentation
-
     * Fix bug that could lead to noindex being activated by accident
 
     * Update Smarty to 3.1.32
@@ -41,10 +39,6 @@ Version 2.2.1-alpha1 (September 20th, 2018)
 
     * Improve internal cache to work with more plugins, by reacting
       to more variables changing the output
-
-    * Fixed bug in pull request #392 which overwrote user specified
-      input for logged in authors with an empty realname (wrong array
-      key name) and deleted all existing text input
 
     * Add backend_view_entry hook, that is executed for every entry
       in the backend entry list
@@ -113,7 +107,7 @@ Version 2.1.3 (August 16th, 2018)
 
     * Disabled subToMe service by default to prevent issues with GDPR
 
-Version 2.1.2 (March 25, 2018))
+Version 2.1.2 (March 25, 2018)
 ------------------------------------------------------------------------
 
     * Exclude defunct netmirror spartacus repository


### PR DESCRIPTION
Remove two items from 2.2.1-alpha1, as they've already been part of 2.1.2.

(And remove a typo.)

Signed-off-by: Thomas Hochstein <thh@inter.net>