### PR TITLE
event_spamblock: Fixed forced comment moderation 0 -> moderate all

### DIFF
--- a/include/admin/upgrader.inc.php
+++ b/include/admin/upgrader.inc.php
@@ -270,6 +270,11 @@ $tasks = array(array('version'   => '0.5.1',
                      'function'  => 'serendipity_installFiles',
                      'title'     => 'Update .htaccess file',
                      'desc'      => 'Adds a new "documentation.*.html" rewrite rule exception to allow calling plugin documentation URLs.'),
+
+               array('version'   => '2.2.1-alpha2',
+                     'function'  => 'serendipity_upgrader_spamblock_moveForce',
+                     'title'     => 'Swap value forcemoderation',
+                     'desc'      => 'If force moderation of comments is activated, activate the new option moderation_auto'),
 );
 
 /* Fetch SQL files which needs to be run */

--- a/include/functions_upgrader.inc.php
+++ b/include/functions_upgrader.inc.php
@@ -423,9 +423,10 @@ function serendipity_upgrader_spamblock_moveForce() {
     global $serendipity;
 
     $force = serendipity_db_query("SELECT value FROM {$serendipity['dbPrefix']}config WHERE name LIKE '%serendipity_event_spamblock%forcemoderation'", true);
+    if (is_array($force)) { $force = $force[0]; }
     if ($force > 0) {
          serendipity_db_query("UPDATE {$serendipity['dbPrefix']}config SET value = 'true' WHERE name LIKE '%serendipity_event_spamblock%moderation_auto'" );
-     }
+    }
 }
 
 function serendipity_upgrader_move_syndication_config() {

--- a/include/functions_upgrader.inc.php
+++ b/include/functions_upgrader.inc.php
@@ -419,6 +419,15 @@ function serendipity_upgrader_rewriteFeedIcon() {
     serendipity_db_query("UPDATE {$serendipity['dbPrefix']}config SET value = '" . serendipity_db_escape_string($path) . "' WHERE name LIKE '%serendipity_plugin_syndication%big_img'");
 }
 
+function serendipity_upgrader_spamblock_moveForce() {
+    global $serendipity;
+
+    $force = serendipity_db_query("SELECT value FROM {$serendipity['dbPrefix']}config WHERE name LIKE '%serendipity_event_spamblock%forcemoderation'", true);
+    if ($force > 0) {
+         serendipity_db_query("UPDATE {$serendipity['dbPrefix']}config SET value = 'true' WHERE name LIKE '%serendipity_event_spamblock%moderation_auto'" );
+     }
+}
+
 function serendipity_upgrader_move_syndication_config() {
     global $serendipity;
     $optionsToPort = array( 'bannerURL'             => 'feedBannerURL',

--- a/plugins/serendipity_event_spamblock/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_spamblock/UTF-8/lang_de.inc.php
@@ -27,8 +27,10 @@
 
 @define('PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_TTL', 'Captchas nach wie vielen Tagen erzwingen');
 @define('PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_TTL_DESC', 'Captchas können abhängig vom Alter des Artikels eingeblendet werden. Tragen Sie das Minimalalter eines Artikels in Tagen ein, ab dem Captchas erforderlich werden sollen. Falls auf 0 gesetzt, sind Captchas immer erforderlich.');
+@define('PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO', 'Automatische Kommentarmoderation nach Alter');
+@define('PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO_DESC', 'Alle Kommentare zu einem Artikel werden abhängig vom Alter des Artikels automatisch moderiert');
 @define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION', 'Kommentarmoderation nach X Tagen erzwingen');
-@define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION_DESC', 'Alle Kommentare zu einem Artikel können abhängig vom Alter des Artikels automatisch moderiert werden. Tragen Sie hier das Minimalalter eines Artikels in Tagen ein, ab dem jeder Kommentar erst nach Ihrer Moderation dargestellt wird. 0 bedeutet, dass keine automatische Moderation erzeugt wird.');
+@define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION_DESC', 'Tragen Sie hier das Minimalalter eines Artikels in Tagen ein, ab dem jeder Kommentar erst nach Ihrer Moderation dargestellt wird. 0 bedeutet, dass alle Kommentare moderiert werden');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_MODERATE', 'Erforderliche Anzahl an Links für Moderation');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_MODERATE_DESC', 'Wenn in einem Kommentar eine bestimmte Anzahl an Links vorhanden ist, kann der Kommentar automatisch moderiert werden. Falls auf 0 gesetzt, wird diese Linkprüfung nicht vorgenommen.');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_REJECT', 'Erforderliche Anzahl an Links für Abweisung');

--- a/plugins/serendipity_event_spamblock/lang_de.inc.php
+++ b/plugins/serendipity_event_spamblock/lang_de.inc.php
@@ -27,8 +27,10 @@
 
 @define('PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_TTL', 'Captchas nach wie vielen Tagen erzwingen');
 @define('PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_TTL_DESC', 'Captchas können abhängig vom Alter des Artikels eingeblendet werden. Tragen Sie das Minimalalter eines Artikels in Tagen ein, ab dem Captchas erforderlich werden sollen. Falls auf 0 gesetzt, sind Captchas immer erforderlich.');
+@define('PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO', 'Automatische Kommentarmoderation nach Alter');
+@define('PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO_DESC', 'Alle Kommentare zu einem Artikel werden abhängig vom Alter des Artikels automatisch moderiert');
 @define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION', 'Kommentarmoderation nach X Tagen erzwingen');
-@define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION_DESC', 'Alle Kommentare zu einem Artikel können abhängig vom Alter des Artikels automatisch moderiert werden. Tragen Sie hier das Minimalalter eines Artikels in Tagen ein, ab dem jeder Kommentar erst nach Ihrer Moderation dargestellt wird. 0 bedeutet, dass keine automatische Moderation erzeugt wird.');
+@define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION_DESC', 'Tragen Sie hier das Minimalalter eines Artikels in Tagen ein, ab dem jeder Kommentar erst nach Ihrer Moderation dargestellt wird. 0 bedeutet, dass alle Kommentare moderiert werden');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_MODERATE', 'Erforderliche Anzahl an Links für Moderation');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_MODERATE_DESC', 'Wenn in einem Kommentar eine bestimmte Anzahl an Links vorhanden ist, kann der Kommentar automatisch moderiert werden. Falls auf 0 gesetzt, wird diese Linkprüfung nicht vorgenommen.');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_REJECT', 'Erforderliche Anzahl an Links für Abweisung');

--- a/plugins/serendipity_event_spamblock/lang_en.inc.php
+++ b/plugins/serendipity_event_spamblock/lang_en.inc.php
@@ -28,8 +28,10 @@
 
 @define('PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_TTL', 'Force captchas after how many days');
 @define('PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_TTL_DESC', 'Captchas can be enforced depending on the age of your articles. Enter the amount of days after which entering a correct captcha is necessary. If set to 0, captchas will always be used.');
+@define('PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO', 'Automatic moderation depending on age');
+@define('PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO_DESC', 'All comments are moderated automatically, depending on the age of the entry');
 @define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION', 'Force comment moderation after how many days');
-@define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION_DESC', 'You can automatically set all comments for entries to be moderated. Enter the age of an entry in days, after which it should be auto-moderated. 0 means no auto-moderation.');
+@define('PLUGIN_EVENT_SPAMBLOCK_FORCEMODERATION_DESC', 'Enter the age of an entry in days, after which it should be auto-moderated. 0 means all comments get moderated.');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_MODERATE', 'How many links before a comment gets moderated');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_MODERATE_DESC', 'When a comment reaches a certain amount of links, that comment can be set to be moderated. 0 means that no link-checking is done.');
 @define('PLUGIN_EVENT_SPAMBLOCK_LINKS_REJECT', 'How many links before a comment gets rejected');

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -1113,7 +1113,9 @@ class serendipity_event_spamblock extends serendipity_event
                         }
 
                         // Check for forced comment moderation (X days)
-                        if ($addData['type'] == 'NORMAL' && $forcemoderation > 0 && $eventData['timestamp'] < (time() - ($forcemoderation * 60 * 60 * 24))) {
+                        if ($addData['type'] == 'NORMAL' && ( 
+                               ( $forcemoderation > 0 && $eventData['timestamp'] < (time() - ($forcemoderation * 60 * 60 * 24)) )  
+                               || ( $forcemoderation == 0 ) ) ) {
                             $this->log($logfile, $eventData['id'], $forcemoderation_treat, PLUGIN_EVENT_SPAMBLOCK_REASON_FORCEMODERATION, $addData);
                             if ($forcemoderation_treat == 'reject') {
                                 $eventData = array('allow_comments' => false);

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -25,7 +25,7 @@ class serendipity_event_spamblock extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '4.1.0'
         ));
-        $propbag->add('version',       '1.86.5');
+        $propbag->add('version',       '1.87');
         $propbag->add('event_hooks',    array(
             'frontend_saveComment' => true,
             'external_plugin'      => true,

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -45,6 +45,7 @@ class serendipity_event_spamblock extends serendipity_event
             'captchas',
             'captchas_ttl',
             'captcha_color',
+            'moderation_auto',
             'forcemoderation',
             'forcemoderation_treat',
             'trackback_ipvalidation' ,
@@ -386,6 +387,13 @@ class serendipity_event_spamblock extends serendipity_event
                 $propbag->add('description', PLUGIN_EVENT_SPAMBLOCK_CAPTCHA_COLOR_DESC);
                 $propbag->add('default', '255,255,255');
                 $propbag->add('validate', '@^[0-9]{1,3},[0-9]{1,3},[0-9]{1,3}$@');
+                break;
+
+            case 'moderation_auto':
+                $propbag->add('type', 'boolean');
+                $propbag->add('name', PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO);
+                $propbag->add('description', PLUGIN_EVENT_SPAMBLOCK_MODERATION_AUTO_DESC);
+                $propbag->add('default', false);
                 break;
 
             case 'forcemoderation':
@@ -829,6 +837,7 @@ class serendipity_event_spamblock extends serendipity_event
                 $show_captcha = false;
             }
 
+            $moderation_auto = $this->get_config('moderation_auto', false);
             $forcemoderation = $this->get_config('forcemoderation', 60);
             $forcemoderation_treat = $this->get_config('forcemoderation_treat', 'moderate');
             $forcemoderationt = $this->get_config('forcemoderationt', 60);
@@ -1113,9 +1122,9 @@ class serendipity_event_spamblock extends serendipity_event
                         }
 
                         // Check for forced comment moderation (X days)
-                        if ($addData['type'] == 'NORMAL' && ( 
-                               ( $forcemoderation > 0 && $eventData['timestamp'] < (time() - ($forcemoderation * 60 * 60 * 24)) )  
-                               || ( $forcemoderation == 0 ) ) ) {
+                        if ($addData['type'] == 'NORMAL' && $moderation_auto == true && ( 
+                               ( $forcemoderation == 0 ) || 
+                               ( $forcemoderation > 0 && $eventData['timestamp'] < (time() - ($forcemoderation * 60 * 60 * 24)) )  ) ) {
                             $this->log($logfile, $eventData['id'], $forcemoderation_treat, PLUGIN_EVENT_SPAMBLOCK_REASON_FORCEMODERATION, $addData);
                             if ($forcemoderation_treat == 'reject') {
                                 $eventData = array('allow_comments' => false);


### PR DESCRIPTION
for the option: "Moderate comments after x days" the function was missing that for a value of 0, all comments are going to be moderated. I fixed this.