### PR TITLE
event_nl2br: fixed isolation issue for pre-tags. Updated description.

### DIFF
--- a/plugins/serendipity_event_nl2br/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_nl2br/UTF-8/lang_de.inc.php
@@ -8,11 +8,11 @@
  */
 
 @define('PLUGIN_EVENT_NL2BR_NAME', 'Textformatierung: NL2BR');
-@define('PLUGIN_EVENT_NL2BR_DESC', 'Konvertiert Zeilenumbrüche zu HTML');
+@define('PLUGIN_EVENT_NL2BR_DESC', 'Konvertiert Zeilenumbrüche zu HTML. Basis-Funktionalität: Konvertiere die Zeilenumbrüche zu <br> - Tags. Erweiterte Funktionalität: Parse den Text in <p>-Tags unter Berücksichtigung der html-Syntax wie p-Elemente nur dort wo sie erlaubt sind, automatische Ignorierung bei vorformatiertem Text mit pre oder innerhalb von style oder svg-Tags.');
 @define('PLUGIN_EVENT_NL2BR_CHECK_MARKUP', 'Überprüfe Markup-Plugins?');
 @define('PLUGIN_EVENT_NL2BR_CHECK_MARKUP_DESC', 'Überprüft automatisch auf existierende Markup-Plugins, um die weitere Ausführung des NL2BR-Plugins zu untersagen. Dies gilt dann, wenn WYSIWYG oder spezifische Markup-Plugins entdeckt werden.');
-@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS', 'Eine Liste von HTML-Tags, innerhalb derer keine Umbrüche bei Benutzung von P-Tags konvertiert werden');
-@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS_DESC', 'Konfigurationsvorschlag: "code,pre,geshi,textarea". Trennen Sie mehrere HTML-Tags mit Komma. Hinweis: Die eingegebenen Tags sind reguläre Ausdrücke!');
+@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS', 'Eine Liste von benutzerdefinierten HTML-Tags, innerhalb derer keine Umbrüche bei Benutzung von P-Tags konvertiert werden');
+@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS_DESC', 'Konfigurationsvorschlag: "nl". Trennen Sie mehrere HTML-Tags mit Komma. Hinweis: Die eingegebenen Tags sind reguläre Ausdrücke!');
 @define('PLUGIN_EVENT_NL2BR_PTAGS', 'Nutze P-Tags');
 @define('PLUGIN_EVENT_NL2BR_PTAGS_DESC', 'Setze statt br-Tags p-Tags ein.');
 @define('PLUGIN_EVENT_NL2BR_ISOBR_TAG', 'ISOBR Isolations-Default BR Einstellung');

--- a/plugins/serendipity_event_nl2br/lang_de.inc.php
+++ b/plugins/serendipity_event_nl2br/lang_de.inc.php
@@ -8,11 +8,11 @@
  */
 
 @define('PLUGIN_EVENT_NL2BR_NAME', 'Textformatierung: NL2BR');
-@define('PLUGIN_EVENT_NL2BR_DESC', 'Konvertiert Zeilenumbrüche zu HTML');
+@define('PLUGIN_EVENT_NL2BR_DESC', 'Konvertiert Zeilenumbrüche zu HTML. Basis-Funktionalität: Konvertiere die Zeilenumbrüche zu <br> - Tags. Erweiterte Funktionalität: Parse den Text in <p>-Tags unter Berücksichtigung der html-Syntax wie p-Elemente nur dort wo sie erlaubt sind, automatische Ignorierung bei vorformatiertem Text mit pre oder innerhalb von style oder svg-Tags.');
 @define('PLUGIN_EVENT_NL2BR_CHECK_MARKUP', 'Überprüfe Markup-Plugins?');
 @define('PLUGIN_EVENT_NL2BR_CHECK_MARKUP_DESC', 'Überprüft automatisch auf existierende Markup-Plugins, um die weitere Ausführung des NL2BR-Plugins zu untersagen. Dies gilt dann, wenn WYSIWYG oder spezifische Markup-Plugins entdeckt werden.');
-@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS', 'Eine Liste von HTML-Tags, innerhalb derer keine Umbrüche bei Benutzung von P-Tags konvertiert werden');
-@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS_DESC', 'Konfigurationsvorschlag: "code,pre,geshi,textarea". Trennen Sie mehrere HTML-Tags mit Komma. Hinweis: Die eingegebenen Tags sind reguläre Ausdrücke!');
+@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS', 'Eine Liste von benutzerdefinierten HTML-Tags, innerhalb derer keine Umbrüche bei Benutzung von P-Tags konvertiert werden');
+@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS_DESC', 'Konfigurationsvorschlag: "nl". Trennen Sie mehrere HTML-Tags mit Komma. Hinweis: Die eingegebenen Tags sind reguläre Ausdrücke!');
 @define('PLUGIN_EVENT_NL2BR_PTAGS', 'Nutze P-Tags');
 @define('PLUGIN_EVENT_NL2BR_PTAGS_DESC', 'Setze statt br-Tags p-Tags ein.');
 @define('PLUGIN_EVENT_NL2BR_ISOBR_TAG', 'ISOBR Isolations-Default BR Einstellung');

--- a/plugins/serendipity_event_nl2br/lang_en.inc.php
+++ b/plugins/serendipity_event_nl2br/lang_en.inc.php
@@ -7,11 +7,11 @@
  */
 
 @define('PLUGIN_EVENT_NL2BR_NAME', 'Markup: NL2BR');
-@define('PLUGIN_EVENT_NL2BR_DESC', 'Convert newlines to BR tags');
+@define('PLUGIN_EVENT_NL2BR_DESC', 'Convert newlines to BR tags. Basic functionality: converts newlines to <br> tags. Extended functionality: parse the text into <p> tags in regard of the html syntax like p tags only where they are allowed, automatically ingnore for preformatted text inside <pre> tags or inside <style> or <svg> tags');
 @define('PLUGIN_EVENT_NL2BR_CHECK_MARKUP', 'Check other markup plugins?');
 @define('PLUGIN_EVENT_NL2BR_CHECK_MARKUP_DESC', 'Automaticly check existing markup plugins to disable the use of NL2BR plugin. This is true, when WYSIWYG or specific markup plugins are detected.');
-@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS', 'A list of HTML-tags where no breaks shall be converted, if using P-Tags');
-@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS_DESC', 'Suggestion: "code,pre,geshi,textarea". Seperate multiple tags with a comma. Hint: The entered tags are evaluated as regular expressions.');
+@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS', 'A list of user defined HTML-tags where no breaks shall be converted, if using P-Tags');
+@define('PLUGIN_EVENT_NL2BR_ISOLATE_TAGS_DESC', 'Suggestion: "nl". Seperate multiple tags with a comma. Hint: The entered tags are evaluated as regular expressions.');
 @define('PLUGIN_EVENT_NL2BR_PTAGS', 'Use P-Tags');
 @define('PLUGIN_EVENT_NL2BR_PTAGS_DESC', 'Insert p-tags instead of br.');
 @define('PLUGIN_EVENT_NL2BR_ISOBR_TAG', 'ISOBR isolations-default BR setting');


### PR DESCRIPTION
I have fixed the display of code or other text which should displayed as it is. Use it with the html pre tag. There was a bug that purged the tag from the output. The newlines were copied into the output, but without the pre-tag, html doesn't display these. 