### PR TITLE
Make sure there is a $serendipity['lang'] defined

### DIFF
--- a/include/functions_config.inc.php
+++ b/include/functions_config.inc.php
@@ -1024,7 +1024,12 @@ function serendipity_getSessionLanguage() {
             if (isset($serendipity['COOKIE']['userDefLang']) && ! empty($serendipity['COOKIE']['userDefLang'])) {
                 $lang = $serendipity['COOKIE']['userDefLang'];
             } else {
-                $lang = $serendipity['lang'];
+                if ($serendipity['lang']) {
+                    $lang = $serendipity['lang'];
+                } else {
+                    // serendipity_load_configuration() failed to load language, go default
+                    $lang = $serendipity['autolang'];
+                }
             }
         }
         $serendipity['detected_lang'] = null;


### PR DESCRIPTION
If for any reason `serendipity_load_configuration()` fails to load conf variable `lang` for author id 0, the fallout is pretty horrible and hard to pinpoint to original source. The emitted error of _PHP Fatal error:  Uncaught Error: Call to undefined function serendipity_mb()_ has very little clues what's really going on. That's why having a fallback in place can be valuable.

Not having `lang` is a corner case, but it can happen, especially for upgraded installations.