### PR TITLE
Remove curly braces array syntax, avoids warning in PHP 7.4.

### DIFF
--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -1320,7 +1320,7 @@ class serendipity_event_spamblock extends serendipity_event
                         imagedestroy($image);
                     } else {
                         header('Content-Type: image/png');
-                        $output_char = strtolower($_SESSION['spamblock']['captcha']{$parts[1] - 1});
+                        $output_char = strtolower($_SESSION['spamblock']['captcha'][$parts[1] - 1]);
                         $cap = $serendipity['serendipityPath'] . 'plugins/serendipity_event_spamblock/captcha_' . $output_char . '.png';
                         if (!file_exists($cap)) {
                             $cap = S9Y_INCLUDE_PATH . 'plugins/serendipity_event_spamblock/captcha_' . $output_char . '.png';


### PR DESCRIPTION
Accessing arrays with a curly brace is deprecated and throws a warning in PHP 7.4:

PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /[path]/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php on line 1323
