### PR TITLE
[event_spartacus] Don't cache wrong plugin list.

### DIFF
--- a/plugins/serendipity_event_spartacus/ChangeLog
+++ b/plugins/serendipity_event_spartacus/ChangeLog
@@ -1,3 +1,7 @@
+2.37.6:
+-------
+    * Fix wrong caching of plugin lists regardless of type.
+
 2.37.5:
 -------
     * Fix missing reset to default after dropping netmirror.

--- a/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
+++ b/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
@@ -27,7 +27,7 @@ class serendipity_event_spartacus extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_SPARTACUS_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking');
-        $propbag->add('version',       '2.37.5');
+        $propbag->add('version',       '2.37.6');
         $propbag->add('requirements',  array(
             'serendipity' => '1.6',
         ));
@@ -711,6 +711,13 @@ class serendipity_event_spartacus extends serendipity_event
     {
         global $serendipity;
         static $pluginlist = null;
+        static $cachedtype = null;
+
+        if (isset($cachedtype) && $cachedtype != $type) {
+            // bust cache if called with other type
+            $pluginlist = null;
+            $cachedtype = $type;
+        }
 
         if ($pluginlist === null) {
             $pluginlist = array();
@@ -736,6 +743,8 @@ class serendipity_event_spartacus extends serendipity_event
                 }
             }
         }
+        // save type of cached pluginlist
+        $cachedtype = $type;
 
         return $pluginlist;
     }


### PR DESCRIPTION
Declaring `$pluginlist` as _static_ will cache the database query results and always return the same list of plugins - no matter which type is queried (sidebar or event).

This cache must be busted if another type of plugins is queried.

Signed-off-by: Thomas Hochstein <thh@inter.net>