### PR TITLE
Add plugin update notifications.

### DIFF
--- a/include/admin/overview.inc.php
+++ b/include/admin/overview.inc.php
@@ -56,6 +56,11 @@ if (is_array($output)) {
 } else {
     $data['updateButton'] = $output;
 }
+if (serendipity_plugin_api::hook_event('backend_plugins_upgradecount', $output)) {
+    $data['pluginUpdates'] = $output;
+} else {
+    $data['pluginUpdates'] = '';
+}
 
 $cjoin  = ($serendipity['serendipityUserlevel'] == USERLEVEL_EDITOR) ? "
         LEFT JOIN {$serendipity['dbPrefix']}authors a ON (e.authorid = a.authorid)

--- a/plugins/serendipity_event_spartacus/ChangeLog
+++ b/plugins/serendipity_event_spartacus/ChangeLog
@@ -1,3 +1,11 @@
+2.38:
+-------
+    * Add function to count upgradeable plugins.
+    * Add upgrade notifier to plugin upgrade button.
+    * Add 'backend_plugins_upgradecount' hook and
+      language constants for a dashboard upgrade
+      notification.
+
 2.37.6:
 -------
     * Fix wrong caching of plugin lists regardless of type.

--- a/plugins/serendipity_event_spartacus/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_spartacus/UTF-8/lang_de.inc.php
@@ -28,6 +28,9 @@
 @define('PLUGIN_EVENT_SPARTACUS_CHECK_EVENT', 'Updates (Ereignis-Plugins)');
 @define('PLUGIN_EVENT_SPARTACUS_CHECK_HINT', 'Sie können mehrere Plugins auf einmal installieren indem sie diesen Link in einem neuen Tab öffnen (mittlerer Mausbutton)');
 
+@define('PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATE', 'Ein Plugin kann aktualisiert werden.');
+@define('PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATES', '%u Plugins können aktualisiert werden.');
+
 @define('PLUGIN_EVENT_SPARTACUS_REPOSITORY_ERROR', '<br />(Der Mirror-Speicherort antwortet mit Fehler %s.)<br />');
 @define('PLUGIN_EVENT_SPARTACUS_HEALTHCHECK', '<p>Die Daten des Spartacus-Speicherorts konnte nicht empfangen werden. Prüfe Verfügbarkeit der Quelle...</p>');
 @define('PLUGIN_EVENT_SPARTACUS_HEALTHERROR', '<p>Die Prüfung der Verfügbarkeit einer Spartacus-Quelle konnte nicht durchgeführt werden (HTTP-Code %s). Bitte probieren Sie es später wieder.</p>');

--- a/plugins/serendipity_event_spartacus/lang_de.inc.php
+++ b/plugins/serendipity_event_spartacus/lang_de.inc.php
@@ -28,6 +28,9 @@
 @define('PLUGIN_EVENT_SPARTACUS_CHECK_EVENT', 'Updates (Ereignis-Plugins)');
 @define('PLUGIN_EVENT_SPARTACUS_CHECK_HINT', 'Sie können mehrere Plugins auf einmal installieren indem sie diesen Link in einem neuen Tab öffnen (mittlerer Mausbutton)');
 
+@define('PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATE', 'Ein Plugin kann aktualisiert werden.');
+@define('PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATES', '%u Plugins können aktualisiert werden.');
+
 @define('PLUGIN_EVENT_SPARTACUS_REPOSITORY_ERROR', '<br />(Der Mirror-Speicherort antwortet mit Fehler %s.)<br />');
 @define('PLUGIN_EVENT_SPARTACUS_HEALTHCHECK', '<p>Die Daten des Spartacus-Speicherorts konnte nicht empfangen werden. Prüfe Verfügbarkeit der Quelle...</p>');
 @define('PLUGIN_EVENT_SPARTACUS_HEALTHERROR', '<p>Die Prüfung der Verfügbarkeit einer Spartacus-Quelle konnte nicht durchgeführt werden (HTTP-Code %s). Bitte probieren Sie es später wieder.</p>');

--- a/plugins/serendipity_event_spartacus/lang_en.inc.php
+++ b/plugins/serendipity_event_spartacus/lang_en.inc.php
@@ -35,6 +35,9 @@
 @define('PLUGIN_EVENT_SPARTACUS_CHECK_EVENT', 'Update event plugins');
 @define('PLUGIN_EVENT_SPARTACUS_CHECK_HINT', 'You can upgrade multiple plugins at once by opening the update-link in a new tab (middle mouse button)');
 
+@define('PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATE', 'A plugin can be updated.');
+@define('PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATES', '%u plugins can be updated.');
+
 @define('PLUGIN_EVENT_SPARTACUS_TRYCURL', 'Trying to use cURL library as fallback...');
 @define('PLUGIN_EVENT_SPARTACUS_CURLFAIL', 'cURL library returned a failure, too.');
 @define('PLUGIN_EVENT_SPARTACUS_HEALTFIREWALLED', 'It was not possible to download the required files from the Spartacus repository, but the health of our repository was retrievable. This means your provider uses a content-based firewall and does not allow to fetch PHP code over the web by using mod_security or other reverse proxies. You either need to ask your provider to turn this off, or you cannot use the Spartacus plugin and need to download files manually.');

--- a/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
+++ b/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
@@ -1322,7 +1322,12 @@ class serendipity_event_spartacus extends serendipity_event
                             echo '    <a id="upgrade_sidebar" class="button_link" href="?serendipity[adminModule]=plugins&amp;serendipity[adminAction]=addnew&amp;serendipity[only_group]=UPGRADE">'. PLUGIN_EVENT_SPARTACUS_CHECK_SIDEBAR .'</a>';
                             echo '    <a id="upgrade_event" class="button_link" href="?serendipity[adminModule]=plugins&amp;serendipity[adminAction]=addnew&amp;serendipity[only_group]=UPGRADE&amp;serendipity[type]=event">'. PLUGIN_EVENT_SPARTACUS_CHECK_EVENT .'</a> ';
                         } else {
-                            echo '    <a id="upgrade_plugins" class="button_link" href="?serendipity[adminModule]=plugins&amp;serendipity[adminAction]=addnew&amp;serendipity[only_group]=UPGRADE' . '&amp;' . serendipity_setFormToken('url') . '">'. PLUGIN_EVENT_SPARTACUS_CHECK .'</a>';
+                            $upgradeCount = $this->count_plugin_upgrades();
+                            $upgradeBadge = '';
+                            if ($upgradeCount > 0) {
+                                $upgradeBadge = sprintf(' (%u)', $upgradeCount);
+                            }
+                            echo '    <a id="upgrade_plugins" class="button_link" href="?serendipity[adminModule]=plugins&amp;serendipity[adminAction]=addnew&amp;serendipity[only_group]=UPGRADE' . '&amp;' . serendipity_setFormToken('url') . '">'. PLUGIN_EVENT_SPARTACUS_CHECK . $upgradeBadge .'</a>';
                         }
                         echo '</div>';
                     }

--- a/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
+++ b/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
@@ -27,7 +27,7 @@ class serendipity_event_spartacus extends serendipity_event
         $propbag->add('description',   PLUGIN_EVENT_SPARTACUS_DESC);
         $propbag->add('stackable',     false);
         $propbag->add('author',        'Garvin Hicking');
-        $propbag->add('version',       '2.37.6');
+        $propbag->add('version',       '2.38');
         $propbag->add('requirements',  array(
             'serendipity' => '1.6',
         ));

--- a/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
+++ b/plugins/serendipity_event_spartacus/serendipity_event_spartacus.php
@@ -40,6 +40,8 @@ class serendipity_event_spartacus extends serendipity_event
 
             'backend_pluginlisting_header'      => true,
 
+            'backend_plugins_upgradecount'      => true,
+
             'external_plugin'                   => true,
 
             'backend_directory_create'          => true,
@@ -1331,6 +1333,22 @@ class serendipity_event_spartacus extends serendipity_event
                         }
                         echo '</div>';
                     }
+                    break;
+
+                case 'backend_plugins_upgradecount':
+                    if (serendipity_db_bool($this->get_config('enable_plugins'))) {
+                        $upgradeCount = $this->count_plugin_upgrades();
+                        if ($upgradeCount > 0) {
+                            if ($upgradeCount > 1) {
+                                $eventData = sprintf(PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATES, $upgradeCount);
+                            } else {
+                                $eventData = PLUGIN_EVENT_SPARTACUS_DASHBOARD_UPDATE;
+                            }
+                            $eventData .= '    <a id="upgrade_plugins" class="button_link" href="?serendipity[adminModule]=plugins&amp;serendipity[adminAction]=addnew&amp;serendipity[only_group]=UPGRADE' . '&amp;' . serendipity_setFormToken('url') . '">'. PLUGIN_EVENT_SPARTACUS_CHECK .'</a>';
+                            return true;
+                        }
+                    }
+                    return false;
                     break;
 
                 case 'backend_templates_fetchlist':

--- a/templates/2k11/admin/overview.inc.tpl
+++ b/templates/2k11/admin/overview.inc.tpl
@@ -37,6 +37,15 @@
         {/if}
     {/if}
 
+    {if $pluginUpdates}
+        <section id="dashboard_plugin_updates">
+            <h3>{$CONST.UPDATE_NOTIFICATION}</h3>
+
+            <span class="msg_notice"><span class="icon-info-circled" aria-hidden="true"></span> {$pluginUpdates}</span>
+        </section>
+        <hr class="separator">
+    {/if}
+
     {if $no_create !== true}
         <section id="dashboard_comments" class="equal_heights quick_list dashboard_widget">
             <h3>{if 'adminComments'|checkPermission}<a href="serendipity_admin.php?serendipity[adminModule]=comments">{/if}{$CONST.COMMENTS}{if 'adminComments'|checkPermission}</a>{/if}</h3>


### PR DESCRIPTION
First pass.

* Count available plugin upgrades.
* Add number of updates to plugin upgrade button.  
  (Could use some improvements, a badge perhaps?)
* Add upgrade notification to dashboard.
  (Could use some polish, too.)

Tested on our "current" test blog, seems to work.

Fixes #423.