### PR TITLE
Add Spartacus links to plugin lists.

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,8 @@
 Version 2.4-alpha1
 ------------------------------------------------------------------------
 
+   * Add Spartacus links ("more info") to plugin lists.
+
    * Fix/Change: Wording of plugin display ("version") and PHP/smarty
                  variable names.
 

--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,10 @@
 Version 2.4-alpha1
 ------------------------------------------------------------------------
 
+   * Fix/Change: Wording of plugin display ("version") and PHP/smarty
+                 variable names.
+
+   * Spartacus: Fix caching of plugin lists in getCachedPlugins().
 
 Version 2.3.0 (10.08.2019)
 ------------------------------------------------------------------------

--- a/include/functions_plugins_admin.inc.php
+++ b/include/functions_plugins_admin.inc.php
@@ -156,6 +156,15 @@ function show_plugins($event_only = false, $sidebars = null)
                 $desc  = '<details class="plugin_data">';
                 $desc .= '<summary><var class="perm_name">'.$cname[0].'</var></summary>';
                 $desc .= '<div class="plugin_desc clearfix">' . serendipity_specialchars($bag->get('description')) . '</div>';
+                if (!empty($plugin_data['path'])) {
+                    if ($event_only) {
+                        $spartacus_type = 'event';
+                    } else {
+                        $spartacus_type = 'sidebar';
+                    }
+                    $desc .= sprintf('<span class="block_level"><a href="http://spartacus.s9y.org/index.php?mode=bygroups_%s_%s#%s">%s</a></span>',
+                             $spartacus_type, $serendipity['lang'], $plugin_data['path'], PLUGIN_LINK_SPARTACUS);
+                }
                 $desc .= '<span class="block_level">' . ucfirst(VERSION)  . ': ' . $bag->get('version') . '</span>';
                 $desc .= '</details>';
 

--- a/lang/UTF-8/serendipity_lang_de.inc.php
+++ b/lang/UTF-8/serendipity_lang_de.inc.php
@@ -1130,3 +1130,5 @@
 @define('MAINTENANCE_MODE_TIME', 'Wartungsmodus aktiv bis');
 @define('MAINTENANCE_MODE_ACTIVATE', 'Aktivieren');
 @define('MAINTENANCE_MODE_DEACTIVATE', 'Deaktivieren');
+
+@define('PLUGIN_LINK_SPARTACUS', 'Weitere Informationen');

--- a/lang/serendipity_lang_de.inc.php
+++ b/lang/serendipity_lang_de.inc.php
@@ -1130,3 +1130,5 @@
 @define('MAINTENANCE_MODE_TIME', 'Wartungsmodus aktiv bis');
 @define('MAINTENANCE_MODE_ACTIVATE', 'Aktivieren');
 @define('MAINTENANCE_MODE_DEACTIVATE', 'Deaktivieren');
+
+@define('PLUGIN_LINK_SPARTACUS', 'Weitere Informationen');

--- a/lang/serendipity_lang_en.inc.php
+++ b/lang/serendipity_lang_en.inc.php
@@ -1129,3 +1129,5 @@
 @define('MAINTENANCE_MODE_TIME', 'Will be active until');
 @define('MAINTENANCE_MODE_ACTIVATE', 'Activate');
 @define('MAINTENANCE_MODE_DEACTIVATE', 'Deactivate');
+
+@define('PLUGIN_LINK_SPARTACUS', 'More information');

--- a/templates/2k11/admin/plugins.inc.tpl
+++ b/templates/2k11/admin/plugins.inc.tpl
@@ -113,6 +113,9 @@
                         {if ! empty($plug.version)}
                             <li class="plugin_version"><b>{$CONST.VERSION|capitalize}:</b> {$plug.version}</li>
                         {/if}
+                        {if ! empty($plug.pluginlocation) && $plug.pluginlocation != 'local'}
+                            <li class="plugin_link"><a href="http://spartacus.s9y.org/index.php?mode=bygroups_{$plug.plugintype}_{$lang}#{$plug.class_name|escape}">{$CONST.PLUGIN_LINK_SPARTACUS}</a></li>
+                        {/if}
                         {if ! empty($plug.website)}
                             <li class="plugin_web"><a href="{$plug.website|escape}">{$CONST.PLUGIN_DOCUMENTATION}</a></li>
                         {/if}


### PR DESCRIPTION
Quite some information is missing from the list of installed plugins; and the list of installable plugins has some more information, but not everything that is present on Spartacus, i.e. the last modification date.

So let's add a link to the plugin entry on Spartacus (in the chosen language version).

Fixes #471.

Signed-off-by: Thomas Hochstein <thh@inter.net>