### PR TITLE
Fix core pagination for "stable archives".

### DIFF
--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -973,11 +973,7 @@ function serendipity_printEntryFooter($suffix = '.html', $totalEntries = null) {
     $uriArguments[] = 'P%s';
     $serendipity['smarty']->assign('footer_totalEntries', $totalEntries);
     $serendipity['smarty']->assign('footer_totalPages', $totalPages);
-    if (serendipity_db_bool($serendipity['archiveSortStable']) && $serendipity['GET']['action'] != 'search') {
-        $serendipity['smarty']->assign('footer_currentPage', $totalPages - $serendipity['GET']['page']);
-    } else {
-        $serendipity['smarty']->assign('footer_currentPage', $serendipity['GET']['page']);
-    }
+    $serendipity['smarty']->assign('footer_currentPage', $serendipity['GET']['page']);
     $serendipity['smarty']->assign('footer_pageLink', str_replace('%2A', '*', serendipity_rewriteURL(implode('/', $uriArguments) . $suffix)));
     $serendipity['smarty']->assign('footer_info', sprintf(PAGE_BROWSE_ENTRIES, serendipity_db_bool($serendipity['archiveSortStable']) && $serendipity['GET']['action'] != 'search' ?  $totalPages - (int)$serendipity['GET']['page'] +1 : (int)$serendipity['GET']['page'], $totalPages, $totalEntries));
 


### PR DESCRIPTION
The current page will always be the current page, regardless of archive sorting order. Page 76 of 86 pages will remain page 76, even if the archive sorting is changed; it won't become page 10.

Fixes #625 in core.

Themes will have to cope with the sorting order in their pagination code if they want to display a descending order for stable archive sorting.

Signed-off-by: Thomas Hochstein <thh@inter.net>