### PR TITLE
Fix pagination for "stable archives" in themes.

### DIFF
--- a/templates/bulletproof/entries.tpl
+++ b/templates/bulletproof/entries.tpl
@@ -418,6 +418,14 @@
 
     {if $template_option.show_pagination == 'true' && $footer_totalPages > 1}
         <div class="pagination">
+            {assign var="archiveSortStable" value="`serendipity_getConfigVar key='archiveSortStable'`"}
+            {if $archiveSortStable}
+                {assign var="linkPrevPage" value="`$footer_next_page`"}
+                {assign var="linkNextPage" value="`$footer_prev_page`"}
+            {else}
+                {assign var="linkPrevPage" value="`$footer_prev_page`"}
+                {assign var="linkNextPage" value="`$footer_next_page`"}
+            {/if}
             {assign var="paginationStartPage" value="`$footer_currentPage-3`"}
             {if $footer_currentPage+3 > $footer_totalPages}
                 {assign var="paginationStartPage" value="`$footer_totalPages-6`"}
@@ -425,8 +433,8 @@
             {if $paginationStartPage <= 0}
                 {assign var="paginationStartPage" value="1"}
             {/if}
-            {if $footer_prev_page}
-                <a title="{$CONST.PREVIOUS_PAGE}" href="{$footer_prev_page}"><span class="pagearrow">&#9668;</span></a>
+            {if $linkPrevPage}
+                <a title="{$CONST.PREVIOUS_PAGE}" href="{$linkPrevPage}"><span class="pagearrow">&#9668;</span></a>
             {/if}
             {if $paginationStartPage > 1}
                 <a href="{$footer_pageLink|replace:'%s':'1'}">1</a>
@@ -447,8 +455,8 @@
             {if $smarty.section.i.index <= $footer_totalPages}
                 <a href="{$footer_pageLink|replace:'%s':$footer_totalPages}">{$footer_totalPages}</a>
             {/if}
-            {if $footer_next_page}
-                <a title="{$CONST.NEXT_PAGE}" href="{$footer_next_page}"><span class="pagearrow">&#9658;</span></a>
+            {if $linkNextPage}
+                <a title="{$CONST.NEXT_PAGE}" href="{$linkNextPage}"><span class="pagearrow">&#9658;</span></a>
             {/if}
         </div>
     {/if}

--- a/templates/timeline/entries.tpl
+++ b/templates/timeline/entries.tpl
@@ -285,6 +285,14 @@
             
         {if $footer_totalPages >1 }
             <nav class="pagination">
+                {assign var="archiveSortStable" value="`serendipity_getConfigVar key='archiveSortStable'`"}
+                {if $archiveSortStable}
+                    {assign var="linkPrevPage" value="`$footer_next_page`"}
+                    {assign var="linkNextPage" value="`$footer_prev_page`"}
+                {else}
+                    {assign var="linkPrevPage" value="`$footer_prev_page`"}
+                    {assign var="linkNextPage" value="`$footer_next_page`"}
+                {/if}
                 {assign var="paginationStartPage" value="`$footer_currentPage-3`"}
                 {if $footer_currentPage+3 > $footer_totalPages}
                     {assign var="paginationStartPage" value="`$footer_totalPages-4`"}
@@ -292,8 +300,8 @@
                 {if $paginationStartPage <= 0}
                     {assign var="paginationStartPage" value="1"}
                 {/if}
-                {if $footer_prev_page}
-                    <a class="btn btn-md btn-default btn-theme" title="{$CONST.PREVIOUS_PAGE}" href="{$footer_prev_page}"><i class="fas fa-arrow-left" aria-hidden="true"></i><span class="sr-only">{$CONST.PREVIOUS_PAGE}</span></a>
+                {if $linkPrevPage}
+                    <a class="btn btn-md btn-default btn-theme" title="{$CONST.PREVIOUS_PAGE}" href="{$linkPrevPage}"><i class="fas fa-arrow-left" aria-hidden="true"></i><span class="sr-only">{$CONST.PREVIOUS_PAGE}</span></a>
                 {/if}
                 {if $paginationStartPage > 1}
                     <a class="btn btn-md btn-default btn-theme" href="{'1'|string_format:$footer_pageLink}">1</a>
@@ -314,8 +322,8 @@
                 {if $smarty.section.i.index <= $footer_totalPages}
                     <a class="btn btn-md btn-default btn-theme" href="{$footer_totalPages|string_format:$footer_pageLink}">{$footer_totalPages}</a>
                 {/if}
-                {if $footer_next_page}
-                    <a class="btn btn-md btn-default btn-theme" title="{$CONST.NEXT_PAGE}" href="{$footer_next_page}"><i class="fas fa-arrow-right" aria-hidden="true"></i><span class="sr-only">{$CONST.NEXT_PAGE}</span></a>
+                {if $linkNextPage}
+                    <a class="btn btn-md btn-default btn-theme" title="{$CONST.NEXT_PAGE}" href="{$linkNextPage}"><i class="fas fa-arrow-right" aria-hidden="true"></i><span class="sr-only">{$CONST.NEXT_PAGE}</span></a>
                 {/if}
             </nav>
         {/if}

--- a/templates/timeline/index.tpl
+++ b/templates/timeline/index.tpl
@@ -114,6 +114,14 @@
             
             {if $footer_totalPages >1 && !isset($staticpage_pagetitle)}
                 <nav class="pagination pull-right">
+                    {assign var="archiveSortStable" value="`serendipity_getConfigVar key='archiveSortStable'`"}
+                    {if $archiveSortStable}
+                        {assign var="linkPrevPage" value="`$footer_next_page`"}
+                        {assign var="linkNextPage" value="`$footer_prev_page`"}
+                    {else}
+                        {assign var="linkPrevPage" value="`$footer_prev_page`"}
+                        {assign var="linkNextPage" value="`$footer_next_page`"}
+                    {/if}
                     {assign var="paginationStartPage" value="`$footer_currentPage-3`"}
                     {if $footer_currentPage+3 > $footer_totalPages}
                         {assign var="paginationStartPage" value="`$footer_totalPages-4`"}
@@ -121,8 +129,8 @@
                     {if $paginationStartPage <= 0}
                         {assign var="paginationStartPage" value="1"}
                     {/if}
-                    {if $footer_prev_page}
-                        <a class="btn btn-md btn-default btn-theme" title="{$CONST.PREVIOUS_PAGE}" href="{$footer_prev_page}"><i class="fa fa-arrow-left" aria-hidden="true"></i><span class="sr-only">{$CONST.PREVIOUS_PAGE}</span></a>
+                    {if $linkPrevPage}
+                        <a class="btn btn-md btn-default btn-theme" title="{$CONST.PREVIOUS_PAGE}" href="{$linkPrevPage}"><i class="fa fa-arrow-left" aria-hidden="true"></i><span class="sr-only">{$CONST.PREVIOUS_PAGE}</span></a>
                     {/if}
                     {if $paginationStartPage > 1}
                         <a class="btn btn-md btn-default btn-theme" href="{'1'|string_format:$footer_pageLink}">1</a>
@@ -143,8 +151,8 @@
                     {if $smarty.section.i.index <= $footer_totalPages}
                         <a class="btn btn-md btn-default btn-theme" href="{$footer_totalPages|string_format:$footer_pageLink}">{$footer_totalPages}</a>
                     {/if}
-                    {if $footer_next_page}
-                        <a class="btn btn-md btn-default btn-theme" title="{$CONST.NEXT_PAGE}" href="{$footer_next_page}"><i class="fa fa-arrow-right" aria-hidden="true"></i><span class="sr-only">{$CONST.NEXT_PAGE}</span></a>
+                    {if $linkNextPage}
+                        <a class="btn btn-md btn-default btn-theme" title="{$CONST.NEXT_PAGE}" href="{$linkNextPage}"><i class="fa fa-arrow-right" aria-hidden="true"></i><span class="sr-only">{$CONST.NEXT_PAGE}</span></a>
                     {/if}
                 </nav>
             {/if}


### PR DESCRIPTION
Timeline and Bulletproof have pagination.

Both need to swap the prev/next links for stable archives, as the sorting order has been reversed.

Signed-off-by: Thomas Hochstein <thh@inter.net>