### PR TITLE
Fix prev/next page links for stable archives.

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.4-alpha1
 ------------------------------------------------------------------------
 
+   * Change footer_info and prev/next links for archive pages for
+     "stable archives" sort order.
+
    * Fix pagination in core for "stable archives" sort order and fix
      prev/next links for pagination in timeline and bulletproof themes
      when "stable archives" are active.

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -975,7 +975,7 @@ function serendipity_printEntryFooter($suffix = '.html', $totalEntries = null) {
     $serendipity['smarty']->assign('footer_totalPages', $totalPages);
     $serendipity['smarty']->assign('footer_currentPage', $serendipity['GET']['page']);
     $serendipity['smarty']->assign('footer_pageLink', str_replace('%2A', '*', serendipity_rewriteURL(implode('/', $uriArguments) . $suffix)));
-    $serendipity['smarty']->assign('footer_info', sprintf(PAGE_BROWSE_ENTRIES, serendipity_db_bool($serendipity['archiveSortStable']) && $serendipity['GET']['action'] != 'search' ?  $totalPages - (int)$serendipity['GET']['page'] +1 : (int)$serendipity['GET']['page'], $totalPages, $totalEntries));
+    $serendipity['smarty']->assign('footer_info', sprintf(PAGE_BROWSE_ENTRIES, (int)$serendipity['GET']['page'], $totalPages, $totalEntries));
 
     if ($serendipity['GET']['page'] < $totalPages) {
         $uriArguments = $serendipity['uriArguments'];
@@ -983,11 +983,6 @@ function serendipity_printEntryFooter($suffix = '.html', $totalEntries = null) {
         $serendipity['smarty']->assign('footer_next_page', serendipity_rewriteURL(str_replace('//', '/', implode('/', $uriArguments)) . $suffix));
     }
 
-    if (serendipity_db_bool($serendipity['archiveSortStable']) && $serendipity['GET']['action'] != 'search') {
-        $temp = $serendipity['smarty']->getTemplateVars('footer_prev_page');
-        $serendipity['smarty']->assign('footer_prev_page', $serendipity['smarty']->getTemplateVars('footer_next_page'));
-        $serendipity['smarty']->assign('footer_next_page', $temp);
-    }
 }
 
 /**


### PR DESCRIPTION
We shouldn't swap prev/next links for archive pages. With stable archives, the title page is the last page of the archive, not the first, so all other pages are "previos", and we should display it like that.

That may seem counterintuitive at first, but otherwise archive page directions and pagination directions don't match (see bulletproof), and we shouldn't count archive pages differently from the URL. With the current code, page 100 of 100 archive pages would be shown in footer_info as page 1, page 99 as page 2, and that doesn't make sense either.

Signed-off-by: Thomas Hochstein <thh@inter.net>