### PR TITLE
Force positive values for fetchLimits.

### DIFF
--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -376,9 +376,11 @@ if (isset($_SESSION['serendipityAuthorid'])) {
     $serendipity['lang'] = serendipity_getPostAuthSessionLanguage();
 }
 
-// Ensure that these limits do not contain strings
+// Ensure that these limits do not contain strings and have positive values
 $serendipity['fetchLimit'] = (int)$serendipity['fetchLimit'];
+if ($serendipity['fetchLimit'] < 1) $serendipity['fetchLimit'] = 1;
 $serendipity['RSSfetchLimit'] = (int)$serendipity['RSSfetchLimit'];
+if ($serendipity['RSSfetchLimit'] < 1) $serendipity['RSSfetchLimit'] = 1;
 
 // Try to fix some path settings. It seems common users have this setting wrong
 // when s9y is installed into the root directory, especially 0.7.1 upgrade users.


### PR DESCRIPTION
The number of entries shown on the title page and in the feed has to be at least "1", as s9y can't cope with "0" or negative values (and it shouldn't).

May be related to #636.

Signed-off-by: Thomas Hochstein <thh@inter.net>