### PR TITLE
Spamblock plugin / last multilingual bugfix

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -1060,6 +1060,7 @@ function serendipity_addCategory($name, $desc, $authorid, $icon, $parentid) {
         'category_description' => $desc
     );
 
+    serendipity_plugin_api::hook_event('multilingual_strip_langs',$data, array('category_name','category_description'));
     serendipity_insertPermalink($data, 'category');
     return $cid;
 }
@@ -1101,6 +1102,7 @@ function serendipity_updateCategory($cid, $name, $desc, $authorid, $icon, $paren
         'category_description' => $desc
     );
 
+    serendipity_plugin_api::hook_event('multilingual_strip_langs',$data, array('category_name','category_description'));
     serendipity_updatePermalink($data, 'category');
 }
 

--- a/include/functions_config.inc.php
+++ b/include/functions_config.inc.php
@@ -400,7 +400,7 @@ function serendipity_login($use_external = true) {
         $user = $serendipity['COOKIE']['author_username'];
         $valid_logintoken = serendipity_checkAutologin($user);
         if ($valid_logintoken === true) {
-            // if we do not tie down the session gere it will be recreated on every page reload, which will fuck op the form token system. That's why we need to load all data that makes the session stick. That's why we call setAuthorToken here.
+            // if we do not tie down the session here it will be recreated on every page reload, which will fuck op the form token system. That's why we need to load all data that makes the session stick. That's why we call setAuthorToken here.
             serendipity_setAuthorToken();
             serendipity_load_userdata($user);
             return true;
@@ -412,7 +412,7 @@ function serendipity_login($use_external = true) {
     }
 
     $data = array('ext' => $use_external, 'mode' => 2, 'user' => $serendipity['POST']['user'], 'pass' => $serendipity['POST']['pass']);
-    serendipity_plugin_api::hook_event('backend_loginfail', $data);
+    if ($use_external) serendipity_plugin_api::hook_event('backend_loginfail', $data);
 }
 
 /**
@@ -542,16 +542,12 @@ function serendipity_authenticate_author($username = '', $password = '', $is_has
 
     if ($debug) fwrite($fp, date('Y-m-d H:i') . ' - Login ext check' . "\n");
     $is_authenticated = false;
-    serendipity_plugin_api::hook_event('backend_login', $is_authenticated, NULL);
-    if ($is_authenticated) {
-        return true;
-    }
+    if ($use_external) serendipity_plugin_api::hook_event('backend_login', $is_authenticated, NULL);
+    if ($is_authenticated) return true;
 
     if ($debug) fwrite($fp, date('Y-m-d H:i') . ' - Login username check:' . $username . "\n");
     if (!empty($username) && is_string($username)) {
-        if ($use_external) {
-            serendipity_plugin_api::hook_event('backend_auth', $is_hashed, array('username' => $username, 'password' => $password));
-        }
+        if ($use_external) serendipity_plugin_api::hook_event('backend_auth', $is_hashed, array('username' => $username, 'password' => $password));
 
         $query = "SELECT DISTINCT
                     email, password, realname, authorid, userlevel, right_publish, hashtype

--- a/include/functions_permalinks.inc.php
+++ b/include/functions_permalinks.inc.php
@@ -474,6 +474,7 @@ function serendipity_buildPermalinks() {
     if (is_array($categories)) {
         serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}permalinks WHERE type = 'category'");
 
+        serendipity_plugin_api::hook_event('multilingual_strip_langs',$categories, array('category_name','category_description'));
         foreach($categories AS $category) {
             serendipity_insertPermalink($category, 'category');
         }

--- a/include/functions_routing.inc.php
+++ b/include/functions_routing.inc.php
@@ -245,6 +245,7 @@ function serveCategory($matches) {
         $serendipity['GET']['category'] = $matches[1];
     }
     $cInfo = serendipity_fetchCategoryInfo($serendipity['GET']['category']);
+    serendipity_plugin_api::hook_event('multilingual_strip_langs',$cInfo, array('category_name'));
 
     if (!is_array($cInfo)) {
         $serendipity['view'] = '404';

--- a/plugins/serendipity_event_nl2br/serendipity_event_nl2br.php
+++ b/plugins/serendipity_event_nl2br/serendipity_event_nl2br.php
@@ -414,7 +414,7 @@ p.wl_notopbottom {
                                 'form', 'header', 'hgroup', 'hr', 'main', 'nav', 'p'
                                 );
 
-    var $nested_block_elements = array('div','table','blockquote','ul','ol','dl');
+    var $nested_block_elements = array('div','table','blockquote','ul','ol','dl','figure');
     
     var $singleton_block_elements = array('hr');
 
@@ -426,7 +426,7 @@ p.wl_notopbottom {
                                 'img', 'input', 'keygen', 'link', 'param', 'source', 
                                 'track', 'wbr', '!--', 'iframe',
                                 'li','tr','th','col','colgroup',
-                                'thead', 'tbody', 'tfoot', 'caption', 'ins','del',
+                                'thead', 'tbody', 'tfoot', 'caption', 'figcaption', 'ins','del',
                                 'video','audio','title','desc','path','circle',
                                 'ellipse', 'rect', 'line', 'polyline', 'polygon', 'text',
                                 'image', 'g', 'defs'); //includes svg tags

--- a/plugins/serendipity_event_nl2br/serendipity_event_nl2br.php
+++ b/plugins/serendipity_event_nl2br/serendipity_event_nl2br.php
@@ -17,8 +17,8 @@ class serendipity_event_nl2br extends serendipity_event
         $propbag->add('name',          PLUGIN_EVENT_NL2BR_NAME);
         $propbag->add('description',   PLUGIN_EVENT_NL2BR_DESC);
         $propbag->add('stackable',     false);
-        $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version',       '2.21.2');
+        $propbag->add('author',        'Serendipity Team, Stephan Brunker');
+        $propbag->add('version',       '2.21.3');
         $propbag->add('requirements',  array(
             'serendipity' => '1.6',
             'smarty'      => '2.6.7',

--- a/plugins/serendipity_event_spamblock/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_spamblock/UTF-8/lang_de.inc.php
@@ -141,3 +141,11 @@
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE', 'URLs von IP Validatierung ausnehmen');
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE_DESC', 'URLs, die von der IP Validatierung ausgeschlossen werden sollen. ' . PLUGIN_EVENT_SPAMBLOCK_FILTER_URLS_DESC);
 
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT', 'Wartezeit zum Kommentieren');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_DESC', 'Festsetzen einer Wartezeit zwischen erstem Anzeigen des Artikels und abgesandtem Kommentar');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE', 'Art der Wartezeit');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE_FIX', 'festgesetzte Zeit');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE_ADAPTIVE', 'abhängig von der Länge von Artikel und Kommentar');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_VALUE', 'Wert für Wartezeit');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_VALUE_DESC', 'festgesetzt: Wartezeit in Sekunden / abhängig: Lesen in Wörtern pro Minute und Schreiben in Zeichen pro Minute. 500 ist hier ein guter Wert selbst für schnelle Leser');
+@define('PLUGIN_EVENT_SPAMBLOCK_REASON_TIMEOUT','Entschuldigung, aber du bist kein Mensch und solltest wenigstens versuchen den Artikel zu lesen bevor ein Kommentar verfasst wird');

--- a/plugins/serendipity_event_spamblock/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_spamblock/UTF-8/lang_de.inc.php
@@ -141,6 +141,8 @@
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE', 'URLs von IP Validatierung ausnehmen');
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE_DESC', 'URLs, die von der IP Validatierung ausgeschlossen werden sollen. ' . PLUGIN_EVENT_SPAMBLOCK_FILTER_URLS_DESC);
 
+@define('PLUGIN_EVENT_SPAMBLOCK_LOGFILE_VALIDATE', 'nur Dateiendungen .log and .txt sind erlaubt');
+
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT', 'Wartezeit zum Kommentieren');
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_DESC', 'Festsetzen einer Wartezeit zwischen erstem Anzeigen des Artikels und abgesandtem Kommentar');
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE', 'Art der Wartezeit');

--- a/plugins/serendipity_event_spamblock/lang_de.inc.php
+++ b/plugins/serendipity_event_spamblock/lang_de.inc.php
@@ -141,6 +141,8 @@
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE', 'URLs von IP Validatierung ausnehmen');
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE_DESC', 'URLs, die von der IP Validatierung ausgeschlossen werden sollen. ' . PLUGIN_EVENT_SPAMBLOCK_FILTER_URLS_DESC);
 
+@define('PLUGIN_EVENT_SPAMBLOCK_LOGFILE_VALIDATE', 'nur Dateiendungen .log and .txt sind erlaubt');
+
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT', 'Wartezeit zum Kommentieren');
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_DESC', 'Festsetzen einer Wartezeit zwischen erstem Anzeigen des Artikels und abgesandtem Kommentar');
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE', 'Art der Wartezeit');

--- a/plugins/serendipity_event_spamblock/lang_de.inc.php
+++ b/plugins/serendipity_event_spamblock/lang_de.inc.php
@@ -141,3 +141,11 @@
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE', 'URLs von IP Validatierung ausnehmen');
 @define('PLUGIN_EVENT_SPAMBLOCK_TRACKBACKIPVALIDATION_URL_EXCLUDE_DESC', 'URLs, die von der IP Validatierung ausgeschlossen werden sollen. ' . PLUGIN_EVENT_SPAMBLOCK_FILTER_URLS_DESC);
 
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT', 'Wartezeit zum Kommentieren');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_DESC', 'Festsetzen einer Wartezeit zwischen erstem Anzeigen des Artikels und abgesandtem Kommentar');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE', 'Art der Wartezeit');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE_FIX', 'festgesetzte Zeit');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE_ADAPTIVE', 'abhängig von der Länge von Artikel und Kommentar');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_VALUE', 'Wert für Wartezeit');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_VALUE_DESC', 'festgesetzt: Wartezeit in Sekunden / abhängig: Lesen in Wörtern pro Minute und Schreiben in Zeichen pro Minute. 500 ist hier ein guter Wert selbst für schnelle Leser');
+@define('PLUGIN_EVENT_SPAMBLOCK_REASON_TIMEOUT','Entschuldigung, aber du bist kein Mensch und solltest wenigstens versuchen den Artikel zu lesen bevor ein Kommentar verfasst wird');

--- a/plugins/serendipity_event_spamblock/lang_en.inc.php
+++ b/plugins/serendipity_event_spamblock/lang_en.inc.php
@@ -147,6 +147,8 @@
 @define('PLUGIN_EVENT_SPAMBLOCK_SPAM', 'Spam');
 @define('PLUGIN_EVENT_SPAMBLOCK_NOT_SPAM', 'Not spam');
 
+@define('PLUGIN_EVENT_SPAMBLOCK_LOGFILE_VALIDATE', 'Only file extensions .log and .txt are allowed');
+
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT', 'Timeout for commenting');
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_DESC', 'Activate a timeout between displaying the article and accepting a comment');
 @define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE', 'Timeout type');

--- a/plugins/serendipity_event_spamblock/lang_en.inc.php
+++ b/plugins/serendipity_event_spamblock/lang_en.inc.php
@@ -147,4 +147,11 @@
 @define('PLUGIN_EVENT_SPAMBLOCK_SPAM', 'Spam');
 @define('PLUGIN_EVENT_SPAMBLOCK_NOT_SPAM', 'Not spam');
 
-@define('PLUGIN_EVENT_SPAMBLOCK_LOGFILE_VALIDATE', 'Only file extensions .log and .txt are allowed');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT', 'Timeout for commenting');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_DESC', 'Activate a timeout between displaying the article and accepting a comment');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE', 'Timeout type');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE_FIX', 'fixed amout of time');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_TYPE_ADAPTIVE', 'depending on the lengths of comment and article');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_VALUE', 'Value for timeout');
+@define('PLUGIN_EVENT_SPAMBLOCK_TIMEOUT_VALUE_DESC', 'type fixed: timeout in seconds / type adaptive: reading in words per minute and typing in chars per minute, 500 is a good value even for fast readers');
+@define('PLUGIN_EVENT_SPAMBLOCK_REASON_TIMEOUT','Sorry, but you are not a human or you should at least attempt to read the article before commenting');

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -357,6 +357,8 @@ class serendipity_event_spamblock extends serendipity_event
                 $propbag->add('name', PLUGIN_EVENT_SPAMBLOCK_LOGFILE);
                 $propbag->add('description', PLUGIN_EVENT_SPAMBLOCK_LOGFILE_DESC);
                 $propbag->add('default', $serendipity['serendipityPath'] . 'spamblock-%Y-%m-%d.log');
+                $propbag->add('validate', '@\.(log|txt)$@imsU');
+                $propbag->add('validate_error', PLUGIN_EVENT_SPAMBLOCK_LOGFILE_VALIDATE);
                 break;
 
             case 'logtype':

--- a/serendipity_admin.php
+++ b/serendipity_admin.php
@@ -32,6 +32,12 @@ if (isset($serendipity['GET']['adminModule']) && $serendipity['GET']['adminModul
         if (!serendipity_userLoggedIn()) {
             // Try again to log in, this time with enabled external authentication event hook
             serendipity_login(true);
+            if (serendipity_userLoggedIn()) {
+                // login with external authentication - reload page to set language settings correct for user
+                include_once S9Y_INCLUDE_PATH . 'include/functions_routing.inc.php';
+                gotoAdmin();
+                return true;
+            }
         }
     }
 }

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -156,42 +156,44 @@ if (!isset($serendipity['dashboardEntriesLimit'])) {
 // Available languages
 if (!isset($serendipity['languages'])) {
     $serendipity['languages'] = array('en' => 'English',
-                                  'de' => 'German',
-                                  'da' => 'Danish',
-                                  'es' => 'Spanish',
-                                  'fr' => 'French',
-                                  'fi' => 'Finnish',
-                                  'cs' => 'Czech (Win-1250)',
-                                  'cz' => 'Czech (ISO-8859-2)',
-                                  'sk' => 'Slovak',
-                                  'nl' => 'Dutch',
-                                  'is' => 'Icelandic',
-                                  'tr' => 'Turkish',
-                                  'se' => 'Swedish',
-                                  'pt' => 'Portuguese Brazilian',
-                                  'pt_PT' => 'Portuguese European',
-                                  'bg' => 'Bulgarian',
-                                  'hu' => 'Hungarian',
-                                  'no' => 'Norwegian',
-                                  'pl' => 'Polish',
-                                  'ro' => 'Romanian',
-                                  'it' => 'Italian',
-                                  'ru' => 'Russian',
-                                  'fa' => 'Persian',
-                                  'tw' => 'Traditional Chinese (Big5)',
-                                  'tn' => 'Traditional Chinese (UTF-8)',
-                                  'zh' => 'Simplified Chinese (GB2312)',
-                                  'cn' => 'Simplified Chinese (UTF-8)',
-                                  'ja' => 'Japanese',
-                                  'ko' => 'Korean',
-                                  'sa' => 'Arabic',
-                                  'ta' => 'Tamil');
+                                  'de' => 'Deutsch',
+                                  'da' => 'Dansk',
+                                  'es' => 'Español',
+                                  'fr' => 'Français',
+                                  'fi' => 'Suomalainen',
+                                  'cs' => 'čeština (Win-1250)',
+                                  'cz' => 'čeština (ISO-8859-2)',
+                                  'sk' => 'Slovenský',
+                                  'nl' => 'Nederlands',
+                                  'is' => 'Íslensku',
+                                  'tr' => 'Türk',
+                                  'se' => 'svenska',
+                                  'pt' => 'português brasileiro',
+                                  'pt_PT' => 'português europeu',
+                                  'bg' => 'Български',
+                                  'hu' => 'magyar',
+                                  'no' => 'norsk',
+                                  'pl' => 'polski',
+                                  'ro' => 'limba română',
+                                  'it' => 'italiano',
+                                  'ru' => 'Русский язык',
+                                  'fa' => 'Fārsī',
+                                  'tw' => '正體字/繁體字 (Big5)',
+                                  'tn' => '正體字/繁體字 (UTF-8)',
+                                  'zh' => '简化字 (GB2312)',
+                                  'cn' => '简化字 (UTF-8)',
+                                  'ja' => '日本語',
+                                  'ko' => '한국어, 조선말',
+                                  'sa' => 'العربية',
+                                  'ta' => 'தமிழ்');
 }
 
 // Available Calendars
 $serendipity['calendars'] = array('gregorian'   => 'Gregorian',
                                   'persian-utf8' => 'Persian (utf8)');
 // Load main language file
+// if installed === false language autodetect or 'en', else nothing happens
+// because serendipity['lang'] is not defined yet
 include($serendipity['serendipityPath'] . 'include/lang.inc.php');
 
 $serendipity['charsets'] = array(
@@ -373,6 +375,9 @@ if (IS_installed === true && php_sapi_name() !== 'cli') {
 
 if (isset($_SESSION['serendipityAuthorid'])) {
     serendipity_load_configuration($_SESSION['serendipityAuthorid']);
+    // load_configuration overwrites $serendipity['lang'], so roll back if another language was detected
+    // in the backend should always the user language be shown
+    // in the frontend logged in same as any other user, exept with fallback to user instead of default
     $serendipity['lang'] = serendipity_getPostAuthSessionLanguage();
 }
 


### PR DESCRIPTION
I have divided it into two commits: One is the fix for the spamblock plugin: It now uses a timeout between showing the page for reading and allowing contents. You can use a fixed amount of time or an adaptive one, depending on reading and writing speed. That is tested and works, now I don't have any spamcomments anymore, but just got a real one with the adaptive setting to 500 words/chars per minute. To circumvent that, the spammers need to keep open each connection for minutes and that probably slows down their operations a bit because they hopefully can't have that big a number of connections parallel. 

The second one is changing the names of the languages to their own languages as was requested in the forum. And fixing the last remaining language bug which was the initialition point of the plugins -> Issue #657 

That second one should be tested by someone who has openid plugin installed. I don't have and don't have openid able accounts, but it should work anyway.