### PR TITLE
functions_routing.php: set action to empty when serving JS

### DIFF
--- a/include/functions_routing.inc.php
+++ b/include/functions_routing.inc.php
@@ -132,6 +132,10 @@ function serveJS($js_mode) {
     header('Content-type: application/javascript; charset=' . LANG_CHARSET);
 
     $out = "";
+    // FIXFIX: including genpage without any given action will generate the
+    // default page which is unneccessary, set action to empty to only make
+    // the fix below
+    $serendipity['GET']['action'] = 'empty';
 
     include(S9Y_INCLUDE_PATH . 'include/genpage.inc.php');
 


### PR DESCRIPTION
I discovered that by working on the nl2br plugin: the event hook 'frontend_display' was called multiple times for every page shown. Also the content to be processed by the plugin was the complete list of recent entries.

The issue originated by a call to the index.php with a serendipityJS request. In include/routing.inc.pnp the serveJS function called genpage in a hacked fix to init smarty, but no action was given. This caused genpage to generate the default content which eats resources and generates additional loading time. I fixed the fix by defining the action to 'empty' which leads to no page generation while serving Javascript.