### PR TITLE
nl2br: a-elements and html comments

### DIFF
--- a/plugins/serendipity_event_nl2br/Changelog
+++ b/plugins/serendipity_event_nl2br/Changelog
@@ -1,2 +1,5 @@
 2.21.3: Include figure and figcaption tags.
         Thanks to @stephanbrunker!
+2.21.4: * changed <a> tags to html5 - can now include every block element
+        * added a new function which processes html comments. Now everything
+          inside an html comment is ignored


### PR DESCRIPTION
I added the functionality that a-elements can contain everything from inline elements to block elements (which is html5 standard)

The plugin now also ignores everything inside html comments.