### PR TITLE
Don't allow requesting an archive page that doesn't exist

### DIFF
--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -406,10 +406,18 @@ function &serendipity_fetchEntries($range = null, $full = true, $limit = '', $fe
 
     if (!empty($limit)) {
         if (isset($serendipity['GET']['page']) && ($serendipity['GET']['page'] > 1 || serendipity_db_bool($serendipity['archiveSortStable'])) && !strstr($limit, ',')) {
-            if (serendipity_db_bool($serendipity['archiveSortStable'])) {
-                $totalEntries = serendipity_getTotalEntries();
+            
+            $totalEntries = serendipity_getTotalEntries();
+            $totalPages = ceil($totalEntries / $limit);
 
-                $totalPages = ceil($totalEntries / $limit);
+            // Do not allow requesting a page that doesn't exist
+            // and do a fallback to the highest page number available
+            if ($serendipity['GET']['page'] > $totalPages) {
+                $serendipity['GET']['page'] = $totalPages;
+            }
+
+            if (serendipity_db_bool($serendipity['archiveSortStable'])) {
+
                 if ($totalPages <= 0 ) {
                     $totalPages = 1;
                 }


### PR DESCRIPTION
Currently, it's possible to request archive pages with a page number higher than the actual page count.

For example, look at https://blog.s9y.org/archives/P999.html - it's requesting page 999 from 47. Furthermore, if you request a *really* high page number, the SQL query will break.

This patch adds a simple check and overwrites the page number in ['GET']['page'] with the highest page number that's currently available.