### PR TITLE
admin template entrylist: entry title was double escaped

### DIFF
--- a/templates/2k11/admin/entries.inc.tpl
+++ b/templates/2k11/admin/entries.inc.tpl
@@ -142,7 +142,7 @@
                         </div>
                     {/if}
 
-                    <h3><a href="?serendipity[action]=admin&amp;serendipity[adminModule]=entries&amp;serendipity[adminAction]=edit&amp;serendipity[id]={$entry.id}" title="#{$entry.id}: {$entry.title|escape}">{$entry.title|escape}</a></h3>
+                    <h3><a href="?serendipity[action]=admin&amp;serendipity[adminModule]=entries&amp;serendipity[adminAction]=edit&amp;serendipity[id]={$entry.id}" title="#{$entry.id}: {$entry.title}">{$entry.title}</a></h3>
 
                     <ul class="plainList clearfix actions">
                     {if $entry.preview || (!$showFutureEntries && ($entry.timestamp >= $serverOffsetHour))}


### PR DESCRIPTION
It was the first time I used html entities in a article title. There were no issues, but in the backend entry list, the title was double-escaped, the entities shown as &lt; etc. This is unnecessary and due to an |escape option in the template. 