### PR TITLE
fix serendipity_killPath()

### DIFF
--- a/include/functions_images.inc.php
+++ b/include/functions_images.inc.php
@@ -1839,6 +1839,7 @@ function serendipity_killPath($basedir, $directory = '', $forceDelete = false) {
     static $serious = true;
 
     if ($handle = @opendir($basedir . $directory)) {
+        $filestack = [];
         while (false !== ($file = @readdir($handle))) {
             if ($file != '.' && $file != '..') {
                 if (is_dir($basedir . $directory . $file)) {


### PR DESCRIPTION
init `$filestack`, important when removing empty folders