### PR TITLE
Prevent renaming ML object into existing file.

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.4-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Fix: Prevent renaming a ML object into an existing file,
+          resulting in deletion of both from disk and database.
+
    * Fix invalid HTTP referrer error when trying to delete a
      trackback from the frontend
 

--- a/include/functions_images.inc.php
+++ b/include/functions_images.inc.php
@@ -2260,6 +2260,10 @@ function serendipity_renameFile($id, $newName, $path = null) {
     $imgBase = $serendipity['serendipityPath'] . $serendipity['uploadPath'];
     
     $newPath = "{$imgBase}{$path}{$newName}.{$file['extension']}";
+
+    if (file_exists($newPath)) {
+        return false;
+    }
     
     rename("{$imgBase}{$file['path']}{$file['realname']}", $newPath);
     


### PR DESCRIPTION
When renaming objects in the Media Library, s9y didn't check if a file with the same name already exists, resulting in a file name collision deleting both files from the database _and_ from disk.

Add a check to avoid that.

An error message would be nice, too, but that may be added later on.

Tested on s9y-stable test instance.

Fixes #666. (The number of the beast.)

Signed-off-by: Thomas Hochstein <thh@inter.net>