### PR TITLE
Set empty limit to "" in serendipity_fetchEntries.

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,8 @@
 Version 2.4-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Fix: Force empty limit to "" in serendipity_fetchEntries().
+
    * Fix: Escape version string in update notifier to avoid XSS.
 
    * Fix: Prevent renaming a ML object into an existing file,

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -435,6 +435,15 @@ function &serendipity_fetchEntries($range = null, $full = true, $limit = '', $fe
         }
 
         $limit = serendipity_db_limit_sql($limit);
+
+    } else {
+        # if $limit was empty(), no limit was set;
+        # but empty() may also mean FALSE, "" or 0,
+        # so set it to "" to remove the LIMIT
+        # statement completely; should catch errors
+        # with a limit of 0 and some database drivers
+        # see <https://github.com/s9y/Serendipity/issues/636>
+        $limit = '';
     }
 
     $query = "SELECT $select_key


### PR DESCRIPTION
If $limit is empty(), no limit is set, so we can set the LIMIT statement to "" to achieve the same.

But an empty() $limit can be "0", so the generated SQL statement could end with "0" instead of the LIMIT statement. We catch this with forcing an empty() $limit to "".

Fixes #636.
(No matter that this shouldn't even happen.)

Signed-off-by: Thomas Hochstein <thh@inter.net>