### PR TITLE
Update spamblock query to work in MySQL 5.7+ with default "strict" mode

### DIFF
--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -498,12 +498,14 @@ class serendipity_event_spamblock extends serendipity_event
 
         // Limit number of banned IPs to prevent .htaccess growing too large. The query selects at max 20*$blocklist_chunksize entries from the last two days.
         $blocklist_chunksize = 177;
-        $q = "SELECT ip FROM {$serendipity['dbPrefix']}spamblock_htaccess WHERE timestamp > " . (time() - 86400*2) . " GROUP BY ip ORDER BY timestamp DESC LIMIT " . 20*$blocklist_chunksize;
+        $q = "SELECT ip, MAX(timestamp) FROM {$serendipity['dbPrefix']}spamblock_htaccess WHERE timestamp > " . (time() - 86400*2) . " GROUP BY ip ORDER BY MAX(timestamp) DESC LIMIT " . 20*$blocklist_chunksize;
         $rows = serendipity_db_query($q, false, 'assoc');
 
         $deny = array();
-        foreach($rows AS $row) {
+        if (is_array($rows)) {
+            foreach($rows AS $row) {
             $deny[] = $row['ip'];
+            }
         }
 
         $hta = $serendipity['serendipityPath'] . '.htaccess';


### PR DESCRIPTION
The old query will fail with ONLY_FULL_GROUP_BY set which is default from
MySQL 5.7.5 onwards. This results in the .htaccess file not being updated.

Also adding some fencing to the foreach to prevent php error messages.

Cf. https://board.s9y.org/viewtopic.php?f=11&t=24753