### PR TITLE
[plugin recententries] Fix multilingual issues

### DIFF
--- a/plugins/serendipity_plugin_recententries/ChangeLog
+++ b/plugins/serendipity_plugin_recententries/ChangeLog
@@ -1,3 +1,6 @@
+2.7.1 * because of changes in the multilingual plugin, 
+        get the options out of the plugin and hard code the SQL for the 
+        multilingual data set
 2.7
     * using the sql condition set aquired by event_hook::'frontend_fetchentries'
       to get the multilingual data set


### PR DESCRIPTION
I had to implement the multilingual SQL in another way. Instead of using the fetchentries event hook, the multilingual data is now fetched directly from the entryproperties table if the multilingual plugin is installed. With the last version of the multilingual and customarchive plugin (additional_plugins/multilingualfix branch), you can switch now between displaying all entries (fallback to default language if untranslated) and display only the translated ones. This change doesn't affect anything outside the multilingual plugin.