### PR TITLE
simplify cookie option code and set security flags httponly and sames…

### DIFF
--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -10,9 +10,13 @@ if (defined('S9Y_FRAMEWORK')) {
 if (!headers_sent() && php_sapi_name() !== 'cli') {
     // Only set the session name, if no session has yet been issued.
     if (session_id() == '') {
-        $cookieParams = session_get_cookie_params();
-        $cookieParams['secure'] = (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on' ? true : false);
-        session_set_cookie_params($cookieParams['lifetime'], $cookieParams['path'], $cookieParams['domain'], $cookieParams['secure'], $cookieParams['httponly']);
+        $secure = (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on');
+        if (PHP_VERSION_ID >= 70300) {
+            session_set_cookie_params(array("secure"=>$secure, "httponly"=>true, "samesite"=>"Lax"));
+        } else {
+            // Support for PHP before 7.3, can be removed at some point
+            session_set_cookie_params(0, '/', '', $secure, true);
+        }
         session_name('s9y_' . md5(dirname(__FILE__)));
         session_start();
     }


### PR DESCRIPTION
…ite=lax

This is a proposal for some security improvements for the session cookie parameters.

First of all I think the existing code had some unnecessary complexities. It first reads out options via session_get_cookie_params(). However there is no other place in the code that sets these parameters, so there should be no reason whatsoever that there are already existing settings that need to be preserved.

The "? true : false" is basically a noop, if we want to set true/false based on a boolean condition we can directly set the condition.

Then the real changes: Set the httponly cookie flag, which is a protection against some forms of XSS exploits (it makes the cookie unavailable to javascript) and lately also a protection against certain forms of spectre-like speculative execution attacks (because the cookie is no longer held in the memory browser rendering process).

I hope there is no javascript code within s9y directly trying to access the cookie, but I haven't seen any obvious breakage so far. Though this should get some testing probably.

Then I'm setting the samesite=lax flag which is a new protection against CSRF attacks. It basically means dangerous cross-site requests (e.g. POST requests) will be sent without the cookie.

I guess the most controversial part of this change is that the array-setting and samesite are only supported with php 7.3 and above. I'm inclined to say "PHP 7.2 is EOL anyway", but... I guess that's controversial :-)

I wanted to provide this for discussion first, but if the PHP 7.3 issue is the only thing keeping this from getting merged I will rework it with some if's so it will still work on older php versions. (Of course that would mean no samesite cookies for older PHPs.)