### PR TITLE
Restrict block display of summary to trackbacks.

### DIFF
--- a/lang/UTF-8/serendipity_lang_cn.inc.php
+++ b/lang/UTF-8/serendipity_lang_cn.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_cs.inc.php
+++ b/lang/UTF-8/serendipity_lang_cs.inc.php
@@ -960,7 +960,7 @@ $i18n_filename_to = array (
 @define('NOTIFICATION_CONFIRM_MAIL',		'Vaše potvrzení komentáře bylo úspěšně přijato.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL',		'Vaše potvrzení žádosti o zasílání oznámení o nových komentářích nemohlo být přijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz starší než 3 týdny, musíte požádat o zasílání oznámení znovu.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL',		'Vaše potvrzení komentáře nemohlo být přijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz starší než 3 týdny, musíte poslat komentář znovu.');
-@define('PLUGIN_DOCUMENTATION',		'Dokumentace');
+@define('PLUGIN_DOCUMENTATION',		'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL',		'Lokální dokumentace');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG',		'Historie verzí');
 @define('SYNDICATION_PLUGIN_BIGIMG',		'Velký obrázek');

--- a/lang/UTF-8/serendipity_lang_cz.inc.php
+++ b/lang/UTF-8/serendipity_lang_cz.inc.php
@@ -960,7 +960,7 @@ $i18n_filename_to = array (
 @define('NOTIFICATION_CONFIRM_MAIL',		'Vaše potvrzení komentáře bylo úspěšně přijato.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL',		'Vaše potvrzení žádosti o zasílání oznámení o nových komentářích nemohlo být přijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz starší než 3 týdny, musíte požádat o zasílání oznámení znovu.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL',		'Vaše potvrzení komentáře nemohlo být přijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz starší než 3 týdny, musíte poslat komentář znovu.');
-@define('PLUGIN_DOCUMENTATION',		'Dokumentace');
+@define('PLUGIN_DOCUMENTATION',		'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL',		'Lokální dokumentace');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG',		'Historie verzí');
 @define('SYNDICATION_PLUGIN_BIGIMG',		'Velký obrázek');

--- a/lang/UTF-8/serendipity_lang_da.inc.php
+++ b/lang/UTF-8/serendipity_lang_da.inc.php
@@ -931,7 +931,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_de.inc.php
+++ b/lang/UTF-8/serendipity_lang_de.inc.php
@@ -926,7 +926,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Die Bestätigung ihres Kommentars wurde erfolgreich verarbeitet.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Ihre Bestätigung des Abonnements einer Kommentarbenachrichtigung konnte nicht verarbeitet werden. Bitte prüfen Sie den Link, den Sie geklickt haben, auf Vollständigkeit. Falls dieser Link vor mehr als 3 Wochen gesendet wurde, müssen Sie eine neue E-Mail anfordern.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Ihre Bestätigung des Kommentars konnte nicht verarbeitet werden. Bitte prüfen Sie den Link, den Sie geklickt haben, auf Vollständigkeit. Falls dieser Link vor mehr als 3 Wochen gesendet wurde, müssen Sie ihr Kommentar erneut senden.');
-@define('PLUGIN_DOCUMENTATION', 'Dokumentation');
+@define('PLUGIN_DOCUMENTATION', 'Webseiten');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Lokale Dokumentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Versionsgeschichte');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Großes Bild');

--- a/lang/UTF-8/serendipity_lang_en.inc.php
+++ b/lang/UTF-8/serendipity_lang_en.inc.php
@@ -930,7 +930,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_es.inc.php
+++ b/lang/UTF-8/serendipity_lang_es.inc.php
@@ -950,7 +950,7 @@ Melvin TODO [20060128]: What spanish word do we use for "referrers" ??
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_fa.inc.php
+++ b/lang/UTF-8/serendipity_lang_fa.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_fi.inc.php
+++ b/lang/UTF-8/serendipity_lang_fi.inc.php
@@ -932,7 +932,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_fr.inc.php
+++ b/lang/UTF-8/serendipity_lang_fr.inc.php
@@ -939,7 +939,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_hu.inc.php
+++ b/lang/UTF-8/serendipity_lang_hu.inc.php
@@ -930,7 +930,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'A hozzászólásod megerősítése sikeresen megtörtént.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'A hozzászólásokról szóló értesítésekre való feliratkozásodat nem sikerült igazolni. Kérlek ellenőrizd az ehhez kapott linket. Ha ezt 3 hétnél régebben kaptad, kérned kell egy új igazoló linket tartalmazó levelet.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'A hozzászólásod jóváhagyása nem sikerült. Kérlek ellenőrizd az erre használt linket. Ha ezt régebben kaptad mint 3 hét, kérned kell egy újat.');
-@define('PLUGIN_DOCUMENTATION', 'Dokumentáció');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Helyi dokumentáció');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Verzió történet');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Nagy kép');

--- a/lang/UTF-8/serendipity_lang_is.inc.php
+++ b/lang/UTF-8/serendipity_lang_is.inc.php
@@ -933,7 +933,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_it.inc.php
+++ b/lang/UTF-8/serendipity_lang_it.inc.php
@@ -936,7 +936,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_nl.inc.php
+++ b/lang/UTF-8/serendipity_lang_nl.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_no.inc.php
+++ b/lang/UTF-8/serendipity_lang_no.inc.php
@@ -935,7 +935,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_pl.inc.php
+++ b/lang/UTF-8/serendipity_lang_pl.inc.php
@@ -931,7 +931,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'a', 'A', 'b', 'B', 'c', 'C', 'c', 'C
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_pt.inc.php
+++ b/lang/UTF-8/serendipity_lang_pt.inc.php
@@ -937,7 +937,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_pt_PT.inc.php
+++ b/lang/UTF-8/serendipity_lang_pt_PT.inc.php
@@ -944,7 +944,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_ro.inc.php
+++ b/lang/UTF-8/serendipity_lang_ro.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_ru.inc.php
+++ b/lang/UTF-8/serendipity_lang_ru.inc.php
@@ -936,7 +936,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_sa.inc.php
+++ b/lang/UTF-8/serendipity_lang_sa.inc.php
@@ -851,7 +851,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_se.inc.php
+++ b/lang/UTF-8/serendipity_lang_se.inc.php
@@ -932,7 +932,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_sk.inc.php
+++ b/lang/UTF-8/serendipity_lang_sk.inc.php
@@ -940,7 +940,7 @@ $i18n_filename_to = array (
 @define('NOTIFICATION_CONFIRM_MAIL', 'Vaše potvrdenie komentára bolo úspešne prijaté.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Vaše potvrdenie žiadosti o zasielanie oznámení o nových komentároch nemohlo byť prijaté. Skontrolujte prosím odkaz, na ktorý ste klikli. Ak je odkaz starší ako 3 týždne, musíte požiadať o zasielanie oznámení znova.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Vaše potvrdenie komentára nemohlo byť prijaté. Skontrolujte prosím odkaz, na ktorý ste klikli. Ak je odkaz starší ako 3 týždne, musíte požiadať o zasielanie oznámení znova.');
-@define('PLUGIN_DOCUMENTATION',		'Dokumentácia');
+@define('PLUGIN_DOCUMENTATION',		'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL',		'Lokálna dokumentácia');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG',		'História verzií');
 @define('SYNDICATION_PLUGIN_BIGIMG',		'Veľký obrázok');

--- a/lang/UTF-8/serendipity_lang_tn.inc.php
+++ b/lang/UTF-8/serendipity_lang_tn.inc.php
@@ -936,7 +936,7 @@ $i18n_unknown = 'tw';
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_tr.inc.php
+++ b/lang/UTF-8/serendipity_lang_tr.inc.php
@@ -936,7 +936,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_tw.inc.php
+++ b/lang/UTF-8/serendipity_lang_tw.inc.php
@@ -937,7 +937,7 @@ $i18n_unknown = 'tw';
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/UTF-8/serendipity_lang_zh.inc.php
+++ b/lang/UTF-8/serendipity_lang_zh.inc.php
@@ -933,7 +933,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_cn.inc.php
+++ b/lang/serendipity_lang_cn.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_cs.inc.php
+++ b/lang/serendipity_lang_cs.inc.php
@@ -960,7 +960,7 @@ $i18n_filename_to = array (
 @define('NOTIFICATION_CONFIRM_MAIL',		'Vaše potvrzení komentáøe bylo úspìšnì pøijato.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL',		'Vaše potvrzení žádosti o zasílání oznámení o nových komentáøích nemohlo být pøijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz starší než 3 týdny, musíte požádat o zasílání oznámení znovu.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL',		'Vaše potvrzení komentáøe nemohlo být pøijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz starší než 3 týdny, musíte poslat komentáø znovu.');
-@define('PLUGIN_DOCUMENTATION',		'Dokumentace');
+@define('PLUGIN_DOCUMENTATION',		'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL',		'Lokální dokumentace');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG',		'Historie verzí');
 @define('SYNDICATION_PLUGIN_BIGIMG',		'Velký obrázek');

--- a/lang/serendipity_lang_cz.inc.php
+++ b/lang/serendipity_lang_cz.inc.php
@@ -960,7 +960,7 @@ $i18n_filename_to = array (
 @define('NOTIFICATION_CONFIRM_MAIL',		'Va¹e potvrzení komentáøe bylo úspì¹nì pøijato.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL',		'Va¹e potvrzení ¾ádosti o zasílání oznámení o nových komentáøích nemohlo být pøijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz star¹í ne¾ 3 týdny, musíte po¾ádat o zasílání oznámení znovu.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL',		'Va¹e potvrzení komentáøe nemohlo být pøijato. Zkontrolujte prosím odkaz, na který jste kliknuli. Pokud je odkaz star¹í ne¾ 3 týdny, musíte poslat komentáø znovu.');
-@define('PLUGIN_DOCUMENTATION',		'Dokumentace');
+@define('PLUGIN_DOCUMENTATION',		'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL',		'Lokální dokumentace');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG',		'Historie verzí');
 @define('SYNDICATION_PLUGIN_BIGIMG',		'Velký obrázek');

--- a/lang/serendipity_lang_da.inc.php
+++ b/lang/serendipity_lang_da.inc.php
@@ -931,7 +931,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_de.inc.php
+++ b/lang/serendipity_lang_de.inc.php
@@ -926,7 +926,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Die Bestätigung ihres Kommentars wurde erfolgreich verarbeitet.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Ihre Bestätigung des Abonnements einer Kommentarbenachrichtigung konnte nicht verarbeitet werden. Bitte prüfen Sie den Link, den Sie geklickt haben, auf Vollständigkeit. Falls dieser Link vor mehr als 3 Wochen gesendet wurde, müssen Sie eine neue E-Mail anfordern.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Ihre Bestätigung des Kommentars konnte nicht verarbeitet werden. Bitte prüfen Sie den Link, den Sie geklickt haben, auf Vollständigkeit. Falls dieser Link vor mehr als 3 Wochen gesendet wurde, müssen Sie ihr Kommentar erneut senden.');
-@define('PLUGIN_DOCUMENTATION', 'Dokumentation');
+@define('PLUGIN_DOCUMENTATION', 'Webseiten');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Lokale Dokumentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Versionsgeschichte');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Großes Bild');

--- a/lang/serendipity_lang_en.inc.php
+++ b/lang/serendipity_lang_en.inc.php
@@ -930,7 +930,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_es.inc.php
+++ b/lang/serendipity_lang_es.inc.php
@@ -950,7 +950,7 @@ Melvin TODO [20060128]: What spanish word do we use for "referrers" ??
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_fa.inc.php
+++ b/lang/serendipity_lang_fa.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_fi.inc.php
+++ b/lang/serendipity_lang_fi.inc.php
@@ -932,7 +932,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_fr.inc.php
+++ b/lang/serendipity_lang_fr.inc.php
@@ -939,7 +939,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_hu.inc.php
+++ b/lang/serendipity_lang_hu.inc.php
@@ -930,7 +930,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'A hozzászólásod megerõsítése sikeresen megtörtént.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'A hozzászólásokról szóló értesítésekre való feliratkozásodat nem sikerült igazolni. Kérlek ellenõrizd az ehhez kapott linket. Ha ezt 3 hétnél régebben kaptad, kérned kell egy új igazoló linket tartalmazó levelet.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'A hozzászólásod jóváhagyása nem sikerült. Kérlek ellenõrizd az erre használt linket. Ha ezt régebben kaptad mint 3 hét, kérned kell egy újat.');
-@define('PLUGIN_DOCUMENTATION', 'Dokumentáció');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Helyi dokumentáció');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Verzió történet');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Nagy kép');

--- a/lang/serendipity_lang_is.inc.php
+++ b/lang/serendipity_lang_is.inc.php
@@ -933,7 +933,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_it.inc.php
+++ b/lang/serendipity_lang_it.inc.php
@@ -936,7 +936,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_nl.inc.php
+++ b/lang/serendipity_lang_nl.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_no.inc.php
+++ b/lang/serendipity_lang_no.inc.php
@@ -935,7 +935,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_pl.inc.php
+++ b/lang/serendipity_lang_pl.inc.php
@@ -931,7 +931,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'a', 'A', 'b', 'B', 'c', 'C', 'c', 'C
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_pt.inc.php
+++ b/lang/serendipity_lang_pt.inc.php
@@ -937,7 +937,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_pt_PT.inc.php
+++ b/lang/serendipity_lang_pt_PT.inc.php
@@ -944,7 +944,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_ro.inc.php
+++ b/lang/serendipity_lang_ro.inc.php
@@ -934,7 +934,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_ru.inc.php
+++ b/lang/serendipity_lang_ru.inc.php
@@ -936,7 +936,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_sa.inc.php
+++ b/lang/serendipity_lang_sa.inc.php
@@ -851,7 +851,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_se.inc.php
+++ b/lang/serendipity_lang_se.inc.php
@@ -932,7 +932,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_sk.inc.php
+++ b/lang/serendipity_lang_sk.inc.php
@@ -940,7 +940,7 @@ $i18n_filename_to = array (
 @define('NOTIFICATION_CONFIRM_MAIL', 'Va¹e potvrdenie komentára bolo úspe¹ne prijaté.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Va¹e potvrdenie ¾iadosti o zasielanie oznámení o nových komentároch nemohlo by» prijaté. Skontrolujte prosím odkaz, na ktorý ste klikli. Ak je odkaz star¹í ako 3 tý¾dne, musíte po¾iada» o zasielanie oznámení znova.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Va¹e potvrdenie komentára nemohlo by» prijaté. Skontrolujte prosím odkaz, na ktorý ste klikli. Ak je odkaz star¹í ako 3 tý¾dne, musíte po¾iada» o zasielanie oznámení znova.');
-@define('PLUGIN_DOCUMENTATION',		'Dokumentácia');
+@define('PLUGIN_DOCUMENTATION',		'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL',		'Lokálna dokumentácia');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG',		'História verzií');
 @define('SYNDICATION_PLUGIN_BIGIMG',		'Veµký obrázok');

--- a/lang/serendipity_lang_ta.inc.php
+++ b/lang/serendipity_lang_ta.inc.php
@@ -932,7 +932,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_tn.inc.php
+++ b/lang/serendipity_lang_tn.inc.php
@@ -936,7 +936,7 @@ $i18n_unknown = 'tw';
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_tr.inc.php
+++ b/lang/serendipity_lang_tr.inc.php
@@ -936,7 +936,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_tw.inc.php
+++ b/lang/serendipity_lang_tw.inc.php
@@ -937,7 +937,7 @@ $i18n_unknown = 'tw';
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');

--- a/lang/serendipity_lang_zh.inc.php
+++ b/lang/serendipity_lang_zh.inc.php
@@ -933,7 +933,7 @@
 @define('NOTIFICATION_CONFIRM_MAIL', 'Your confirmation of the comment has been successfully entered.');
 @define('NOTIFICATION_CONFIRM_SUBMAIL_FAIL', 'Your comment subscription could not be confirmed. Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must request a new confirmation mail.');
 @define('NOTIFICATION_CONFIRM_MAIL_FAIL', 'Your comment confirmation could not be confirmed.  Please check the link you clicked on for completion. If the link was sent more than 3 weeks ago, you must send your comment again.');
-@define('PLUGIN_DOCUMENTATION', 'Documentation');
+@define('PLUGIN_DOCUMENTATION', 'Website');
 @define('PLUGIN_DOCUMENTATION_LOCAL', 'Local Documentation');
 @define('PLUGIN_DOCUMENTATION_CHANGELOG', 'Version history');
 @define('SYNDICATION_PLUGIN_BIGIMG', 'Big Image');


### PR DESCRIPTION
summary elements in the entry body should get a triangle symbol displayed (as we do in the backend).

Signed-off-by: Thomas Hochstein <thh@inter.net>