### PR TITLE
[plugin_comments] Don't strip HTML unconditionally.

### DIFF
--- a/plugins/serendipity_plugin_comments/ChangeLog
+++ b/plugins/serendipity_plugin_comments/ChangeLog
@@ -1,3 +1,8 @@
+Version 1.17:
+------------------------------------------------------------------------
+* Fix: Don't strip HTML tags from comment body before truncating if 
+       serendipity_event_unstrip_tags is active, so it may actually
+       preserve the tags (and replace them with entities).
 Version 1.16:
 ------------------------------------------------------------------------
 * Fix: wordwrap at word boundaries instead of "truncating" the lines

--- a/plugins/serendipity_plugin_comments/serendipity_plugin_comments.php
+++ b/plugins/serendipity_plugin_comments/serendipity_plugin_comments.php
@@ -20,7 +20,7 @@ class serendipity_plugin_comments extends serendipity_plugin
         $propbag->add('description',   PLUGIN_COMMENTS_BLAHBLAH);
         $propbag->add('stackable',     true);
         $propbag->add('author',        'Garvin Hicking, Tadashi Jokagi, Judebert, G. Brockhaus');
-        $propbag->add('version',       '1.16');
+        $propbag->add('version',       '1.17');
         $propbag->add('requirements',  array(
             'serendipity' => '1.6',
             'smarty'      => '2.6.7',
@@ -193,11 +193,17 @@ class serendipity_plugin_comments extends serendipity_plugin
 
         if ($sql && is_array($sql)) {
             foreach($sql AS $key => $row) {
+                # don't strip HTML tags if serendipity_event_unstrip_tags is active
+                if (!class_exists('serendipity_event_unstrip_tags')) {
+                    $comment = strip_tags($row['comment']);
+                } else {
+                    $comment = $row['comment'];
+                }
                 # truncate comment to $max_chars
                 if (function_exists('mb_strimwidth')) {
-                    $comment = mb_strimwidth(strip_tags($row['comment']), 0, $max_chars, " [...]", LANG_CHARSET);
+                    $comment = mb_strimwidth($comment, 0, $max_chars, " [...]", LANG_CHARSET);
                 } else {
-                    $comments = wordwrap(strip_tags($row['comment']), $max_chars, '@@@', 1);
+                    $comments = wordwrap($comment, $max_chars, '@@@', 1);
                     $aComment = explode('@@@', $comments);
                     $comment  = $aComment[0];
                     if (count($aComment) > 1) {


### PR DESCRIPTION
If serendipity_event_unstrip_tags is active, we don't want to strip HTML tags from comments; we want to keep and encode them with entities. So we should do that here, too.

As the frontend_display hook - that is catched by serendipity_event_unstrip_tags - is called quite late, we have to skip the strip_tags() call before truncatin the entry.

(I'm not sure why we first strip _all_ tags and later on keep _some_ tags (that have already been removed), but that's maybe because the frontend_display hook may have re-added some tags? Be it as it may, we do that for 14 years, so I don't want to change that now.)

Signed-off-by: Thomas Hochstein <thh@inter.net>