### PR TITLE
Restrict block display of summary to trackbacks.

### DIFF
--- a/templates/2k11/style.css
+++ b/templates/2k11/style.css
@@ -1,4 +1,4 @@
-article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section { display: block; }
 audio, canvas, video { display: inline-block; *display: inline; *zoom: 1; }
 audio:not([controls]) { display: none; }
 [hidden] { display: none; }
@@ -445,6 +445,10 @@ fieldset,
     color: #666;
     font-size: .8125em;
     line-height: 1.8462;
+}
+
+.serendipity_section_trackbacks summary {
+    display: block;
 }
 
 #staticpage_childpages,


### PR DESCRIPTION
Summary elements in the entry body should get a triangle symbol displayed (as we do in the backend).

Signed-off-by: Thomas Hochstein <thh@inter.net>