### PR TITLE
escape filter words for regexp

### DIFF
--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -1536,7 +1536,7 @@ class serendipity_event_spamblock extends serendipity_event
                     if (empty($filter_body)) {
                         continue;
                     }
-                    if (preg_match('@(' . $filter_body . ')@i', $addData['comment'], $wordmatch)) {
+                    if (preg_match('@(' . preg_quote($filter_body) . ')@i', $addData['comment'], $wordmatch)) {
                         if ($filter_type == 'moderate') {
                             $this->log($logfile, $eventData['id'], 'MODERATE', PLUGIN_EVENT_SPAMBLOCK_FILTER_WORDS . ': ' . $wordmatch[1], $addData);
                             $eventData['moderate_comments'] = true;


### PR DESCRIPTION
I noticed that using unusual characters ('[') in a filter keyword resulted in a regular expression error in the PHP logs (and no filtering).
The issue is that the filter is using regexps, but not escaping the filter keywords. Patch fixes this.