### PR TITLE
Feature dateselector

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,3 +1,4 @@
+   * Split date and time input in editor into two input fields
    * Improve performance of the media library by caching the file list
 
 Version 2.4-alpha2 ()

--- a/include/admin/entries.inc.php
+++ b/include/admin/entries.inc.php
@@ -60,17 +60,22 @@ switch($serendipity['GET']['adminAction']) {
         }
 
         // Check if the user changed the timestamp.
-        if (isset($serendipity['allowDateManipulation']) && $serendipity['allowDateManipulation'] && isset($serendipity['POST']['new_timestamp']) && $serendipity['POST']['new_timestamp'] != date(DATE_FORMAT_2, $serendipity['POST']['chk_timestamp'])) {
-            // The user changed the timestamp, now set the DB-timestamp to the user's date
-            $entry['timestamp'] = strtotime($serendipity['POST']['new_timestamp']);
+        if (isset($serendipity['POST']['new_date']) && isset($serendipity['POST']['new_time'])) {
+            $newTimestamp = $serendipity['POST']['new_date'] . 'T' . $serendipity['POST']['new_time'];
+        
+            if (isset($serendipity['allowDateManipulation']) && $serendipity['allowDateManipulation'] && $newTimestamp != date(DATE_FORMAT_2, $serendipity['POST']['chk_timestamp'])) {
+                // The user changed the timestamp, now set the DB-timestamp to the user's date
+                $entry['timestamp'] = strtotime($newTimestamp);
 
-            if ($entry['timestamp'] == -1) {
-                $data['switched_output'] = true;
-                $data['dateval'] = false;
-                // The date given by the user is not convertable. Reset the timestamp.
-                $entry['timestamp'] = $serendipity['POST']['timestamp'];
+                if ($entry['timestamp'] == -1) {
+                    $data['switched_output'] = true;
+                    $data['dateval'] = false;
+                    // The date given by the user is not convertable. Reset the timestamp.
+                    $entry['timestamp'] = $serendipity['POST']['timestamp'];
+                }
             }
         }
+        
 
         // Save server timezone in database always, so substract the offset we added for display; otherwise it would be added time and again
         if (!empty($entry['timestamp'])) {

--- a/lang/UTF-8/serendipity_lang_bg.inc.php
+++ b/lang/UTF-8/serendipity_lang_bg.inc.php
@@ -26,6 +26,7 @@ $i18n_filename_to   = array('-', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('TYPE', 'Tип');
 @define('PREVIEW', 'Преглед');
 @define('DATE', 'Дата');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Изглед');
 @define('LOGIN', 'Влизане');
 @define('LOGOUT', 'Излизане');

--- a/lang/UTF-8/serendipity_lang_cn.inc.php
+++ b/lang/UTF-8/serendipity_lang_cn.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', '类型');
 @define('PREVIEW', '预览');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '主要配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/UTF-8/serendipity_lang_cs.inc.php
+++ b/lang/UTF-8/serendipity_lang_cs.inc.php
@@ -52,6 +52,7 @@ $i18n_filename_to = array (
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Ukázat');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Vzhled');
 @define('LOGIN', 'Přihlášení');
 @define('LOGOUT', 'Odhlášení');

--- a/lang/UTF-8/serendipity_lang_cz.inc.php
+++ b/lang/UTF-8/serendipity_lang_cz.inc.php
@@ -52,6 +52,7 @@ $i18n_filename_to = array (
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Ukázat');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Vzhled');
 @define('LOGIN', 'Přihlášení');
 @define('LOGOUT', 'Odhlášení');

--- a/lang/UTF-8/serendipity_lang_da.inc.php
+++ b/lang/UTF-8/serendipity_lang_da.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Vis');
 @define('DATE', 'Dato');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Udseende');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Log ud');

--- a/lang/UTF-8/serendipity_lang_de.inc.php
+++ b/lang/UTF-8/serendipity_lang_de.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Vorschau');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aussehen');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Abmelden');

--- a/lang/UTF-8/serendipity_lang_en.inc.php
+++ b/lang/UTF-8/serendipity_lang_en.inc.php
@@ -20,6 +20,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Preview');
 @define('DATE', 'Date');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Appearance');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Logout');

--- a/lang/UTF-8/serendipity_lang_es.inc.php
+++ b/lang/UTF-8/serendipity_lang_es.inc.php
@@ -32,6 +32,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Previsualización');
 @define('DATE', 'Fecha');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Apariencia');
 @define('LOGIN', 'Conectar');
 @define('LOGOUT', 'Desconectar');

--- a/lang/UTF-8/serendipity_lang_fa.inc.php
+++ b/lang/UTF-8/serendipity_lang_fa.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'نوع');
 @define('PREVIEW', 'پیش نمایش');
 @define('DATE', 'تاریخ');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'ظاهر');
 @define('LOGIN', 'ورود');
 @define('LOGOUT', 'خروج');

--- a/lang/UTF-8/serendipity_lang_fi.inc.php
+++ b/lang/UTF-8/serendipity_lang_fi.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Tyyppi');
 @define('PREVIEW', 'Esikatselu');
 @define('DATE', 'Päiväys');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Ulkoasu');
 @define('LOGIN', 'Kirjaudu');
 @define('LOGOUT', 'Poistu');

--- a/lang/UTF-8/serendipity_lang_fr.inc.php
+++ b/lang/UTF-8/serendipity_lang_fr.inc.php
@@ -24,6 +24,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Prévisualisation');
 @define('DATE', 'Date');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Apparence');
 @define('LOGIN', 'Se connecter');
 @define('LOGOUT', 'Se déconnecter');

--- a/lang/UTF-8/serendipity_lang_hu.inc.php
+++ b/lang/UTF-8/serendipity_lang_hu.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Típus');
 @define('PREVIEW', 'Előnézet');
 @define('DATE', 'Dátum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Kinézet');
 @define('LOGIN', 'Belépés');
 @define('LOGOUT', 'Kilépés');

--- a/lang/UTF-8/serendipity_lang_is.inc.php
+++ b/lang/UTF-8/serendipity_lang_is.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Tegund');
 @define('PREVIEW', 'Skoða');
 @define('DATE', 'Dagsetning');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Útlit');
 @define('LOGIN', 'Skrá inn');
 @define('LOGOUT', 'Skrá út');

--- a/lang/UTF-8/serendipity_lang_it.inc.php
+++ b/lang/UTF-8/serendipity_lang_it.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Anteprima');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aspetto');
 @define('LOGIN', 'Entra');
 @define('LOGOUT', 'Esci');

--- a/lang/UTF-8/serendipity_lang_ja.inc.php
+++ b/lang/UTF-8/serendipity_lang_ja.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', '種類');
 @define('PREVIEW', 'プレビュー');
 @define('DATE', '日付');
+@define('TIME', 'Time');
 @define('APPEARANCE', '外観');
 @define('LOGIN', 'ログイン');
 @define('LOGOUT', 'ログアウト');

--- a/lang/UTF-8/serendipity_lang_ko.inc.php
+++ b/lang/UTF-8/serendipity_lang_ko.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', '종류');
 @define('PREVIEW', '미리보기');
 @define('DATE', '날짜');
+@define('TIME', 'Time');
 @define('APPEARANCE', '외관');
 @define('LOGIN', '로그인');
 @define('LOGOUT', '로그아웃');

--- a/lang/UTF-8/serendipity_lang_nl.inc.php
+++ b/lang/UTF-8/serendipity_lang_nl.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Voorvertoning');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Uiterlijk');
 @define('LOGIN', 'Aanmelden');
 @define('LOGOUT', 'Afmelden');

--- a/lang/UTF-8/serendipity_lang_no.inc.php
+++ b/lang/UTF-8/serendipity_lang_no.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Vis');
 @define('DATE', 'Dato');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Utseende');
 @define('LOGIN', 'Logg inn');
 @define('LOGOUT', 'Logg ut');

--- a/lang/UTF-8/serendipity_lang_pl.inc.php
+++ b/lang/UTF-8/serendipity_lang_pl.inc.php
@@ -22,6 +22,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'a', 'A', 'b', 'B', 'c', 'C', 'c', 'C
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Podgląd');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Wygląd');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Logout');

--- a/lang/UTF-8/serendipity_lang_pt.inc.php
+++ b/lang/UTF-8/serendipity_lang_pt.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Pré-visualização');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aparência');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Logout');

--- a/lang/UTF-8/serendipity_lang_pt_PT.inc.php
+++ b/lang/UTF-8/serendipity_lang_pt_PT.inc.php
@@ -24,6 +24,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Pré-visualização');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aparência');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Sair');

--- a/lang/UTF-8/serendipity_lang_ro.inc.php
+++ b/lang/UTF-8/serendipity_lang_ro.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Tip');
 @define('PREVIEW', 'Previzualizare');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aspect');
 @define('LOGIN', 'Conectare');
 @define('LOGOUT', 'Deconectat');

--- a/lang/UTF-8/serendipity_lang_ru.inc.php
+++ b/lang/UTF-8/serendipity_lang_ru.inc.php
@@ -23,6 +23,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('TYPE', 'Тип');
 @define('PREVIEW', 'Предварительный просмотр');
 @define('DATE', 'Дата');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Внешний вид');
 @define('LOGIN', 'Войти');
 @define('LOGOUT', 'Выйти');

--- a/lang/UTF-8/serendipity_lang_sa.inc.php
+++ b/lang/UTF-8/serendipity_lang_sa.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'نوع');
 @define('PREVIEW', 'مشاهدة المشاركة');
 @define('DATE', 'التاريخ');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'ظهور');
 @define('LOGIN', 'تسجيل الدخول');
 @define('LOGOUT', 'خروج');

--- a/lang/UTF-8/serendipity_lang_se.inc.php
+++ b/lang/UTF-8/serendipity_lang_se.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Förhandsgranska');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Utseende');
 @define('LOGIN', 'Logga in');
 @define('LOGOUT', 'Logga ut');

--- a/lang/UTF-8/serendipity_lang_sk.inc.php
+++ b/lang/UTF-8/serendipity_lang_sk.inc.php
@@ -33,6 +33,7 @@ $i18n_filename_to = array (
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Náhľad');
 @define('DATE', 'Dátum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Vzhľad');
 @define('LOGIN', 'Prihlásenie');
 @define('LOGOUT', 'Odhlásenie');

--- a/lang/UTF-8/serendipity_lang_ta.inc.php
+++ b/lang/UTF-8/serendipity_lang_ta.inc.php
@@ -20,6 +20,7 @@
 @define('TYPE', 'வகை');
 @define('PREVIEW', 'முன்காட்சி');
 @define('DATE', 'தேதி');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'தோற்றம்');
 @define('LOGIN', 'வலைக்குறிப்பு நிர்வாகத்திற்கு நல்வரவு');
 @define('LOGOUT', 'விடைபெறுங்கள்');

--- a/lang/UTF-8/serendipity_lang_tn.inc.php
+++ b/lang/UTF-8/serendipity_lang_tn.inc.php
@@ -23,6 +23,7 @@ $i18n_unknown = 'tw';
 @define('TYPE', '類型');
 @define('PREVIEW', '預覽');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '外觀配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/UTF-8/serendipity_lang_tr.inc.php
+++ b/lang/UTF-8/serendipity_lang_tr.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Türü');
 @define('PREVIEW', 'Önizleme');
 @define('DATE', 'Tarih');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Görünüm');
 @define('LOGIN', 'Bağlan');
 @define('LOGOUT', 'Çıkış');

--- a/lang/UTF-8/serendipity_lang_tw.inc.php
+++ b/lang/UTF-8/serendipity_lang_tw.inc.php
@@ -23,6 +23,7 @@ $i18n_unknown = 'tw';
 @define('TYPE', '類型');
 @define('PREVIEW', '預覽');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '外觀配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/UTF-8/serendipity_lang_zh.inc.php
+++ b/lang/UTF-8/serendipity_lang_zh.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', '类型');
 @define('PREVIEW', '预览');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '主要配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/serendipity_lang_bg.inc.php
+++ b/lang/serendipity_lang_bg.inc.php
@@ -26,6 +26,7 @@ $i18n_filename_to   = array('-', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('TYPE', 'Tип');
 @define('PREVIEW', 'Преглед');
 @define('DATE', 'Дата');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Изглед');
 @define('LOGIN', 'Влизане');
 @define('LOGOUT', 'Излизане');

--- a/lang/serendipity_lang_cn.inc.php
+++ b/lang/serendipity_lang_cn.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', '类型');
 @define('PREVIEW', '预览');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '主要配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/serendipity_lang_cs.inc.php
+++ b/lang/serendipity_lang_cs.inc.php
@@ -52,6 +52,7 @@ $i18n_filename_to = array (
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Ukázat');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Vzhled');
 @define('LOGIN', 'Pøihlášení');
 @define('LOGOUT', 'Odhlášení');

--- a/lang/serendipity_lang_cz.inc.php
+++ b/lang/serendipity_lang_cz.inc.php
@@ -52,6 +52,7 @@ $i18n_filename_to = array (
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Ukázat');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Vzhled');
 @define('LOGIN', 'Pøihlá¹ení');
 @define('LOGOUT', 'Odhlá¹ení');

--- a/lang/serendipity_lang_da.inc.php
+++ b/lang/serendipity_lang_da.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Vis');
 @define('DATE', 'Dato');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Udseende');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Log ud');

--- a/lang/serendipity_lang_de.inc.php
+++ b/lang/serendipity_lang_de.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Vorschau');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aussehen');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Abmelden');

--- a/lang/serendipity_lang_en.inc.php
+++ b/lang/serendipity_lang_en.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Preview');
 @define('DATE', 'Date');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Appearance');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Logout');

--- a/lang/serendipity_lang_es.inc.php
+++ b/lang/serendipity_lang_es.inc.php
@@ -33,6 +33,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Previsualización');
 @define('DATE', 'Fecha');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Apariencia');
 @define('LOGIN', 'Conectar');
 @define('LOGOUT', 'Desconectar');

--- a/lang/serendipity_lang_fa.inc.php
+++ b/lang/serendipity_lang_fa.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'نوع');
 @define('PREVIEW', 'پیش نمایش');
 @define('DATE', 'تاریخ');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'ظاهر');
 @define('LOGIN', 'ورود');
 @define('LOGOUT', 'خروج');

--- a/lang/serendipity_lang_fi.inc.php
+++ b/lang/serendipity_lang_fi.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Tyyppi');
 @define('PREVIEW', 'Esikatselu');
 @define('DATE', 'Päiväys');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Ulkoasu');
 @define('LOGIN', 'Kirjaudu');
 @define('LOGOUT', 'Poistu');

--- a/lang/serendipity_lang_fr.inc.php
+++ b/lang/serendipity_lang_fr.inc.php
@@ -24,6 +24,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Prévisualisation');
 @define('DATE', 'Date');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Apparence');
 @define('LOGIN', 'Se connecter');
 @define('LOGOUT', 'Se déconnecter');

--- a/lang/serendipity_lang_hu.inc.php
+++ b/lang/serendipity_lang_hu.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Típus');
 @define('PREVIEW', 'Elõnézet');
 @define('DATE', 'Dátum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Kinézet');
 @define('LOGIN', 'Belépés');
 @define('LOGOUT', 'Kilépés');

--- a/lang/serendipity_lang_is.inc.php
+++ b/lang/serendipity_lang_is.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Tegund');
 @define('PREVIEW', 'Skoða');
 @define('DATE', 'Dagsetning');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Útlit');
 @define('LOGIN', 'Skrá inn');
 @define('LOGOUT', 'Skrá út');

--- a/lang/serendipity_lang_it.inc.php
+++ b/lang/serendipity_lang_it.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Anteprima');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aspetto');
 @define('LOGIN', 'Entra');
 @define('LOGOUT', 'Esci');

--- a/lang/serendipity_lang_ja.inc.php
+++ b/lang/serendipity_lang_ja.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', '種類');
 @define('PREVIEW', 'プレビュー');
 @define('DATE', '日付');
+@define('TIME', 'Time');
 @define('APPEARANCE', '外観');
 @define('LOGIN', 'ログイン');
 @define('LOGOUT', 'ログアウト');

--- a/lang/serendipity_lang_ko.inc.php
+++ b/lang/serendipity_lang_ko.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', '종류');
 @define('PREVIEW', '미리보기');
 @define('DATE', '날짜');
+@define('TIME', 'Time');
 @define('APPEARANCE', '외관');
 @define('LOGIN', '로그인');
 @define('LOGOUT', '로그아웃');

--- a/lang/serendipity_lang_nl.inc.php
+++ b/lang/serendipity_lang_nl.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Voorvertoning');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Uiterlijk');
 @define('LOGIN', 'Aanmelden');
 @define('LOGOUT', 'Afmelden');

--- a/lang/serendipity_lang_no.inc.php
+++ b/lang/serendipity_lang_no.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Type');
 @define('PREVIEW', 'Vis');
 @define('DATE', 'Dato');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Utseende');
 @define('LOGIN', 'Logg inn');
 @define('LOGOUT', 'Logg ut');

--- a/lang/serendipity_lang_pl.inc.php
+++ b/lang/serendipity_lang_pl.inc.php
@@ -22,6 +22,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'a', 'A', 'b', 'B', 'c', 'C', 'c', 'C
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Podgl±d');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Wygl±d');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Logout');

--- a/lang/serendipity_lang_pt.inc.php
+++ b/lang/serendipity_lang_pt.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Pré-visualização');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aparência');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Logout');

--- a/lang/serendipity_lang_pt_PT.inc.php
+++ b/lang/serendipity_lang_pt_PT.inc.php
@@ -24,6 +24,7 @@
 @define('TYPE', 'Tipo');
 @define('PREVIEW', 'Pré-visualização');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aparência');
 @define('LOGIN', 'Login');
 @define('LOGOUT', 'Sair');

--- a/lang/serendipity_lang_ro.inc.php
+++ b/lang/serendipity_lang_ro.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Tip');
 @define('PREVIEW', 'Previzualizare');
 @define('DATE', 'Data');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Aspect');
 @define('LOGIN', 'Conectare');
 @define('LOGOUT', 'Deconectat');

--- a/lang/serendipity_lang_ru.inc.php
+++ b/lang/serendipity_lang_ru.inc.php
@@ -23,6 +23,7 @@ $i18n_filename_to   = array('_', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('TYPE', 'Тип');
 @define('PREVIEW', 'Предварительный просмотр');
 @define('DATE', 'Дата');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Внешний вид');
 @define('LOGIN', 'Войти');
 @define('LOGOUT', 'Выйти');

--- a/lang/serendipity_lang_sa.inc.php
+++ b/lang/serendipity_lang_sa.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'äæÚ');
 @define('PREVIEW', 'ãÔÇåÏÉ ÇáãÔÇÑßÉ');
 @define('DATE', 'ÇáÊÇÑíÎ');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'ÙåæÑ');
 @define('LOGIN', 'ÊÓÌíá ÇáÏÎæá');
 @define('LOGOUT', 'ÎÑæÌ');

--- a/lang/serendipity_lang_se.inc.php
+++ b/lang/serendipity_lang_se.inc.php
@@ -21,6 +21,7 @@
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Förhandsgranska');
 @define('DATE', 'Datum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Utseende');
 @define('LOGIN', 'Logga in');
 @define('LOGOUT', 'Logga ut');

--- a/lang/serendipity_lang_sk.inc.php
+++ b/lang/serendipity_lang_sk.inc.php
@@ -33,6 +33,7 @@ $i18n_filename_to = array (
 @define('TYPE', 'Typ');
 @define('PREVIEW', 'Náhµad');
 @define('DATE', 'Dátum');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Vzhµad');
 @define('LOGIN', 'Prihlásenie');
 @define('LOGOUT', 'Odhlásenie');

--- a/lang/serendipity_lang_ta.inc.php
+++ b/lang/serendipity_lang_ta.inc.php
@@ -20,6 +20,7 @@
 @define('TYPE', 'வகை');
 @define('PREVIEW', 'முன்காட்சி');
 @define('DATE', 'தேதி');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'தோற்றம்');
 @define('LOGIN', 'வலைக்குறிப்பு நிர்வாகத்திற்கு நல்வரவு');
 @define('LOGOUT', 'விடைபெறுங்கள்');

--- a/lang/serendipity_lang_tn.inc.php
+++ b/lang/serendipity_lang_tn.inc.php
@@ -23,6 +23,7 @@ $i18n_unknown = 'tw';
 @define('TYPE', '類型');
 @define('PREVIEW', '預覽');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '外觀配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/serendipity_lang_tr.inc.php
+++ b/lang/serendipity_lang_tr.inc.php
@@ -22,6 +22,7 @@
 @define('TYPE', 'Türü');
 @define('PREVIEW', 'Önizleme');
 @define('DATE', 'Tarih');
+@define('TIME', 'Time');
 @define('APPEARANCE', 'Görünüm');
 @define('LOGIN', 'Bağlan');
 @define('LOGOUT', 'Çıkış');

--- a/lang/serendipity_lang_tw.inc.php
+++ b/lang/serendipity_lang_tw.inc.php
@@ -23,6 +23,7 @@ $i18n_unknown = 'tw';
 @define('TYPE', '類型');
 @define('PREVIEW', '預覽');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '外觀配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/lang/serendipity_lang_zh.inc.php
+++ b/lang/serendipity_lang_zh.inc.php
@@ -23,6 +23,7 @@
 @define('TYPE', '类型');
 @define('PREVIEW', '预览');
 @define('DATE', '日期');
+@define('TIME', 'Time');
 @define('APPEARANCE', '主要配置');
 @define('LOGIN', '登入');
 @define('LOGOUT', '登出');

--- a/templates/2k11/admin/entries.tpl
+++ b/templates/2k11/admin/entries.tpl
@@ -98,9 +98,13 @@
         {if $entry_vars.allowDateManipulation}
             <div id="edit_entry_timestamp" class="form_field">
                 <input name="serendipity[chk_timestamp]" type="hidden" value="{$entry_vars.timestamp|escape}">
-
-                <label for="serendipityNewTimestamp">{$CONST.DATE}</label>
-                <input id="serendipityNewTimestamp" name="serendipity[new_timestamp]" type="datetime-local" value="{$entry_vars.timestamp|formatTime:'Y-m-d\TH:i':true:false:true}">
+                
+                <label for="serendipityNewDate">{$CONST.DATE}</label>
+                <input id="serendipityNewDate" name="serendipity[new_date]" type="date" value="{$entry_vars.timestamp|formatTime:'Y-m-d':true:false:true}">
+                
+                <label for="serendipityNewTime">{$CONST.TIME}</label>
+                <input id="serendipityNewTime" name="serendipity[new_time]" type="time" value="{$entry_vars.timestamp|formatTime:'H:i':true:false:true}">
+                
             </div>
         {/if}
             <div id="edit_entry_status" class="form_select">

--- a/templates/2k11/admin/serendipity_editor.js.tpl
+++ b/templates/2k11/admin/serendipity_editor.js.tpl
@@ -1056,9 +1056,6 @@ $(function() {
     // Make the timestamp readable in browser not supporting datetime-local.
     // Has no effect in those supporting it, as the timestamp is invalid in HTML5
     if($('#serendipityEntry').length > 0) {
-        if(!Modernizr.inputtypes.date) {
-            $('#serendipityNewTimestamp').val($('#serendipityNewTimestamp').val().replace("T", " "));
-        }
         if(Modernizr.indexeddb && {$use_autosave}) {
             serendipity.startEntryEditorCache();
         }
@@ -1066,10 +1063,11 @@ $(function() {
 
     // Set entry timestamp
     $('#reset_timestamp').click(function(e) {
-        $('#serendipityNewTimestamp').val($(this).attr('data-currtime'));
-        if(!Modernizr.inputtypes.date) {
-            $('#serendipityNewTimestamp').val($('#serendipityNewTimestamp').val().replace("T", " "));
-        }
+        var curDate = $(this).attr('data-currtime').replace(/T.*/, '');
+        var curTime = $(this).attr('data-currtime').replace(/.*T/, '');
+        $('#serendipityNewDate').val(curDate);
+        $('#serendipityNewTime').val(curTime);
+        
         e.preventDefault();
         // Inline notification, we might want to make this reuseable
         $('<span id="msg_timestamp" class="msg_notice"><span class="icon-info-circled" aria-hidden="true"></span>{$CONST.TIMESTAMP_RESET} <a class="remove_msg" href="#msg_timestamp"><span class="icon-cancel" aria-hidden="true"></span><span class="visuallyhidden">{$CONST.HIDE}</span></a></span>').insertBefore('#edit_entry_title');


### PR DESCRIPTION
This PR splits the datetime selector. 

Support to get a proper datetime-local selector in the browser is not happening outside of chromium, we have waited for years. But a date and a time selector is available in both chromium and firefox. By using those we can make it easier for users of Firefox without worsening the situation for Chromium users too much.

Alternative would be a polyfill, but I'm not aware of one that actually works. I also did not find a proper alternative datetime selector widget we could use instead (but there might be something available).