### PR TITLE
Secure random token generation

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -530,7 +530,7 @@ function serendipity_sendMail($to, $subject, $message, $fromMail, $headers = NUL
             $maildata['headers'][] = 'X-Mailer: ' . $maildata['version'];
             $maildata['headers'][] = 'X-Engine: PHP/'. phpversion();
         }
-        $maildata['headers'][] = 'Message-ID: <'. md5(microtime() . uniqid(time())) .'@'. $_SERVER['HTTP_HOST'] .'>';
+        $maildata['headers'][] = 'Message-ID: <'. bin2hex(random_bytes(16)) .'@'. $_SERVER['HTTP_HOST'] .'>';
         $maildata['headers'][] = 'MIME-Version: 1.0';
         $maildata['headers'][] = 'Precedence: bulk';
         $maildata['headers'][] = 'Content-Type: text/plain; charset=' . LANG_CHARSET;

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -842,7 +842,7 @@ function serendipity_insertComment($id, $commentInfo, $type = 'NORMAL', $source 
         $subscribe = 'false';
     }
 
-    $dbhash   = md5(uniqid(rand(), true));
+    $dbhash = bin2hex(random_bytes(16));
 
     if ($status == 'confirm') {
         $dbstatus = 'confirm' . $dbhash;
@@ -1230,7 +1230,7 @@ function serendipity_generateCToken($cid) {
 
     global $serendipity;
 
-    $ctoken = md5(uniqid(rand(),1));
+    $ctoken = bin2hex(random_bytes(16));
     
         //Delete any comment tokens older than 1 week.
         serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}options

--- a/include/functions_config.inc.php
+++ b/include/functions_config.inc.php
@@ -502,7 +502,7 @@ function serendipity_checkAutologin($user) {
  * Set a session cookie which can identify a user across http/https boundaries
  */
 function serendipity_setAuthorToken() {
-    $hash = sha1(uniqid(rand(), true));
+    $hash = bin2hex(random_bytes(20));
     serendipity_setCookie('author_token', $hash);
     $_SESSION['author_token'] = $hash;
 }

--- a/include/plugin_api.inc.php
+++ b/include/plugin_api.inc.php
@@ -228,7 +228,7 @@ class serendipity_plugin_api
     {
         global $serendipity;
 
-        $id = md5(uniqid(''));
+        $id = bin2hex(random_bytes(16));
 
         $key = $plugin_class_id . ':' . $id;
         $key = serendipity_db_escape_string($key);


### PR DESCRIPTION
In several places in the code a combination of a hash function and uniqid is used to generate random tokens, e.g. "md5(uniqid(rand(),1));".

These should be replaced with calls to random_bytes() (and turned to hex strings with bin2hex), which guarantees secure random numbers. random_bytes() is available since PHP 7.0, which is s9y's minimum php version, and the function already used at other places in the code, so there should not be any compatibility concerns.