### PR TITLE
Wysiwyg cleanup

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,4 +1,5 @@
-   * Drop never fully itnegrated laminas-db powered database backend
+   * Remove multitude of wysiwyg toolbars
+   * Drop never fully integrated laminas-db powered database backend
    * Update Cache/Lite to 1.8.3 for better PHP 7.4 compat
    * Change backend_image_add hook to always contain same structure
    * Split date and time input in editor into two input fields

--- a/htmlarea/ckeditor_s9y_config.js
+++ b/htmlarea/ckeditor_s9y_config.js
@@ -1,131 +1,38 @@
 /**
- * @fileOverview The Serendipity CKEDITOR custom config file:
- *               ckeditor_s9y_config.js, v. 1.15, last modified 2015-08-15 by Ian
- */
-
-/**
- * Substitute every config option to CKEDITOR in here.
- * Before you do, copy and rename the file to ckeditor_custom_config.js and
+ * Config of CKEDITOR.
+ * Before you change options, copy and rename the file to ckeditor_custom_config.js and
  * place it to /templates/2k11/admin, or to your template in /templates/xxx/admin.
- * Leave this file here unchanged!
- * In your custom copy change anything needed to be upgrade independent
- * NOTE: Use at own risk! Be careful!
+ * In your custom copy change anything needed to be upgrade independent.
+ *
+ * See https://ckeditor.com/docs/ckeditor4/latest/guide/dev_configuration.html.
  */
 CKEDITOR.editorConfig = function( config ) {
 
     config.allowedContent = true;
-
-    /** SECTION: Other behaviour config rules
-
-    // Prevent filler nodes in all empty blocks. - case switching source and wysiwyg mode multiple times
-    //config.fillEmptyBlocks = false; // default (true) - switches <p>&nbsp;</p> to <p></p>
-    //config.ignoreEmptyParagraph = false; // default(true) - Whether the editor must output an empty value ('') if it's contents is made by an empty paragraph only. (Extends to config.fillEmptyBlocks)
-    // changed for extraAllowedContent, see above
-    //config.autoParagraph = false; // defaults(true)
-    // DEV NOTES: Please note that since CKEditor 4.4.5 the config.autoParagraph configuration option was marked deprecated, since changing the default value might introduce unpredictable usability issues and so it is highly unrecommended.
-
-    // The configuration setting that controls the ENTER mode is "config.enterMode" and it offers three options:
-    // (1) The default creates a paragraph element each time the "enter" key is pressed:
-    //config.enterMode = CKEDITOR.ENTER_P; // inserts <p></p>
-    // (2) You can choose to create a "div" element instead of a paragraph:
-    //config.enterMode = CKEDITOR.ENTER_DIV; // inserts <div></div>
-    // (3) If you prefer to not wrap the text in anything, you can choose to insert a line break tag:
-    //config.enterMode = CKEDITOR.ENTER_BR; // inserts <br />
-    // You can always use SHIFT+ENTER to set a br in the P-mode default option or change the SHIFT-mode to something else
-    //config.shiftEnterMode = CKEDITOR.ENTER_BR;
-    // Better learn to do this via keyboard commands, see cheatsheet toolbar button.
-    */
-
-    // Whether to use HTML entities in the output. Let strictly S9y handle this, since we need it for search terms! Storing html entities to db is not good here!
-    config.entities = false; // defaults(true)
-    config.htmlEncodeOutput = false; // defaults(true)
-
-
-    /** SECTION: UI configurations
-    config.uiColor = 'transparent'; // standard, but better disable config.uiColor at all
-    // just some examples
-    config.uiColor = '#CFD1CF'; // standard grey
-    config.uiColor = '#f5f5f5'; // standard light grey
-    config.uiColor = '#E6EDF3'; // extreme light blue
-    config.uiColor = '#DFE8F6'; // very light blue
-    config.uiColor = '#9AB8F3'; // light blue/violet
-    config.uiColor = '#AADC6E'; // light green
-    config.uiColor = '#FFDC6E'; // light gold
-    config.uiColor = '#FF8040'; // mango
-    config.uiColor = '#FF2400'; // scarlet red
-    config.uiColor = '#14B8C4'; // light turquoise
-    */
     config.skin    = 'moono-lisa'; // this is default
     config.height  = 400; // dito
-
-    /**
-    // Allow certain font sizes, eg.
-    //config.fontSize_sizes = '8/8px;9/9px;10/10px;11/11px;12/12px;14/14px;15/15px;16/16px;18/18px;20/20px;22/22px;24/24px;26/26px;28/28px;36/36px;48/48px;72/72px' ;
-    // Allow one(!) default font label, eg.
-    //config.font_defaultLabel = 'Arial';
-    // Add other font names to the list of fonts names to be displayed in the Font combo in the toolbar. - eg.
-    //config.font_names = config.font_names +
-    //    'Arial/Arial, Helvetica, sans-serif;' +
-    //    'Times New Roman/Times New Roman, Times, serif;' +
-    //    'Verdana';
-    */
-
-
-    /** SECTION: Custom Config Content Styles
-        We can not use templates/xxx/admin/ as a path here, since we would need template and userTemplate path parts as dynamic vars
-    */
     // Add custom Serendipity styles to ckeditor content wysiwyg-mode, to repect css image floats
     config.contentsCss = 'htmlarea/wysiwyg-style.css';
 
-
-    /** SECTION: Custom Plugin and Button behaviour configurations **/
-    /**
-    // Native spell check functionality is by default disabled in the editor, use this to enable it.
-    // Do not wonder if this is not working on demand, since Browsers need to match spell checker settings, etc., you need to hit the correct place/word, and so on.
-    //config.disableNativeSpellChecker = false;
-    // [CRTL + right mouse click] gives access to Browsers contextmenu, else you need to disable and set these
-    // The general idea is that you would need to remove all plugins that depend on the "contextmenu" one for removing the "contextmenu" one itself to work. But this has other sideeffects!
-    //config.removePlugins = 'wsc,scayt,menubutton,liststyle,tabletools,contextmenu';
-    //config.browserContextMenuOnCtrl = true;
-    //config.wsc_lang = 'de_DE'; //Defaults to: 'en_US'
-    //config.scayt_sLang = 'de_DE'; //Defaults to: 'en_US'
-    */
-
-    // Remove custom toolbar buttons and plugins from all toolbars
     // A list of plugins that must not be loaded. This setting makes it possible to avoid loading some plugins defined in the CKEDITOR.config.plugins setting, without having to touch it and potentially break it.
-    config.removePlugins = 'flash,iframe,forms'; // possible strict suggestions: 'flash,iframe,elementspath,save,font,showblocks,div,liststyle,pagebreak,smiley,specialchar,horizontalrule,indentblock,justify,pastefromword,newpage,preview,print,stylescombo'
-    config.removeButtons = 'Preview,Styles,JustifyLeft'; // these buttons are useless or preset in Serendipity and therefore not set. Without, even the toolbar Groups break better on screens.
+    config.removePlugins = 'flash,iframe,forms'; 
+    config.removeButtons = 'Preview,Styles,JustifyLeft'; // these buttons are useless or preset in Serendipity and therefore not set.
 
-
-    /** SECTION: Certain Plugin Buttons
-        We cheat ckeditor instances by adding all available button names (in s9ypluginbuttons) to "both" toolbar instances, in case of having two textareas.
-        The instantiation will only take the ones being currently initiated in wysiwyg_init.tpl output, in the source code.
-        The hooked and added extraPlugins in wysiwyg_init become not automatically true for preset toolbars (Basic, Standard, Full) like this, but do for the fallback toolbarGroups later on.
-    */
-    // concat button arrays
     var s9ypluginbuttonsAll = s9ymediabuttons.concat(s9ypluginbuttons);
 
 
-    /** SECTION: Build Preset Toolbars
+    /** Preset Toolbars
 
         S9Y: Serendipity (default)
+        FULL: Serendipity (extended)
+
+        Deprecated:
         BASIC: Serendipity (simple)
         STANDARD: Serendipity (normal)
-        FULL: Serendipity (extended)
         CKE: CKEditor Full (preset)
+        * */
 
-        PLEASE NOTE:
-        1. In order to work properly within all toolbars, please do not remove the eg. { name: 'insert', items: [ 'Image' ] }, group and Image button, since then the s9ymediabutton does not properly insert!
-           This ckeditor image widget is disabled/hidden by css (htmlarea/s9y_cketoolbar.css) and is only presented in the CKE PRESET toolbar.
-        2. If you really configure your own toolbar, choose the named and selected toolbar which comes near to your idea and edit the one.
-    */
 
-    /** DEBUG core and custom file accessment
-//    console.log('is ckeditor_s9y_config.js');
-//    console.log('is ckeditor_custom_config.js');
-    */
-
-    // in case of Serendipity toolbar : "Basic"
     config.toolbar_Basic = [
         { name: 'styles',      items : [ 'Format', ] },
         { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Superscript' ] },
@@ -137,9 +44,7 @@ CKEDITOR.editorConfig = function( config ) {
         { name: 'others',      items : s9ypluginbuttons },
         { name: 'document',    items : [ 'Source' ] }
     ];
-//    console.log(JSON.stringify(config.toolbar_Basic));
 
-    // in case of Serendipity toolbar : "Standard" (called 'Alternate' in toolbar selection, but rather is a normal Standard)
     config.toolbar_Standard = [
         { name: 'basicstyles', items : [ 'Format','-','Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] },
         { name: 'clipboard',   items : [ 'Cut', 'Copy', 'Paste', 'PasteText', '-', 'Undo', 'Redo'] },
@@ -156,18 +61,14 @@ CKEDITOR.editorConfig = function( config ) {
         { name: 'cheatsheet',  items : ['CheatSheet'] },
         { name: 'tools',       items : [ 'Maximize' ] }
     ];
-//    console.log(JSON.stringify(config.toolbar_Standard));
 
-    // in case of Serendipity toolbar : "Full"
-    // Breaks apart long paragraph group to better float (moved 'Source' and removed 'Font' buttons; 'Styles' and 'Preview' disabled overall).
     config.toolbar_Full = [
-        { name: 'styles',      items : [ 'Styles','Format',/*'Font',*/'FontSize' ] },
+        { name: 'styles',      items : [ 'Styles','Format','FontSize' ] },
         { name: 'basicstyles', items : [ 'Bold','Italic','Underline','Strike','Subscript','Superscript','-','RemoveFormat' ] },
         { name: 'clipboard',   items : [ 'Cut','Copy','Paste','PasteText','PasteFromWord','-','Undo','Redo' ] },
-        { name: 'document',    items : [ /*'Source','-',*/'Save','NewPage','DocProps','Preview','Print','-','Templates' ] },
+        { name: 'document',    items : [ 'Save','NewPage','DocProps','Preview','Print','-','Templates' ] },
         { name: 'editing',     items : [ 'Find','Replace','-','SelectAll','-','SpellChecker', 'Scayt' ] },
         { name: 'forms',       items : [ 'Form', 'Checkbox', 'Radio', 'TextField', 'Textarea', 'Select', 'Button', 'ImageButton', 'HiddenField' ] },
-//        { name: 'paragraph',   items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','Blockquote','CreateDiv','-','JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock','-','BidiLtr','BidiRtl' ] },
         { name: 'paragraph',   items : [ 'NumberedList','BulletedList','-','Outdent','Indent','-','Blockquote','-','CreateDiv' ] },
         { name: 'blocks',      items : [ 'JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock' ] },
         { name: 'bidi',        items : [ 'BidiLtr','BidiRtl' ] },
@@ -182,9 +83,7 @@ CKEDITOR.editorConfig = function( config ) {
         { name: 'document',   groups : [ 'mode', 'document', 'doctools' ], items : [ 'Source' ] },
         { name: 'cheatsheet',  items : ['CheatSheet'] },
     ];
-//    console.log(JSON.stringify(config.toolbar_Full));
 
-    // in case of Serendipity toolbar : Default
     config.toolbar_Default = [
         { name: 'tools',        items: [ 'Maximize' ] },
         { name: 'styles',       items: [ 'Format' ] },
@@ -201,16 +100,7 @@ CKEDITOR.editorConfig = function( config ) {
         { name: 'document',    groups: [ 'mode', 'document', 'doctools' ], items: [ 'Source' ] },
         { name: 'about',        items: [ 'About' ] },
     ];
-//    console.log(JSON.stringify(config.toolbar_s9y));
 
-    /**
-     This is the 'CKE PRESET' toolbar select name with CKE 'Default' values, also acting as a fallback in order. Do not touch!
-     Note: There is another (internal) fallback toolbar in case of errors, which appearance looks like a re-arranged 4-liner toolbar,
-           which will provide the 'others' group, but no additionally added plugins (like mediaembed and cheatsheet).
-     This is the official Toolbar configuration generated automatically by the editor, based on config.toolbarGroups.
-     It is more or like an untouched example for the full toolbar but underlies the same restrictions of disabled plugins or buttons.
-    */
-    // in case of toolbar : PRESET CKE
     config.toolbar_CKE = [
         { name: 'document', groups: [ 'mode', 'document', 'doctools' ], items: [ 'Source', '-', 'Save', 'NewPage', 'Preview', 'Print', '-', 'Templates' ] },
         { name: 'clipboard', groups: [ 'clipboard', 'undo' ], items: [ 'Cut', 'Copy', 'Paste', 'PasteText', 'PasteFromWord', '-', 'Undo', 'Redo' ] },
@@ -228,29 +118,7 @@ CKEDITOR.editorConfig = function( config ) {
         { name: 'others', items : s9ypluginbuttonsAll },
         { name: 'about', items: [ 'About' ] }
     ];
-
-    /*
-    // This is the official Toolbar groups and order configuration. Added here for comparison with ours.
-    config.toolbarGroups = [
-        { name: 'document', groups: [ 'mode', 'document', 'doctools' ] },
-        { name: 'clipboard', groups: [ 'clipboard', 'undo' ] },
-        { name: 'editing', groups: [ 'find', 'selection', 'spellchecker' ] },
-        { name: 'forms' },
-        '/',
-        { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
-        { name: 'paragraph', groups: [ 'list', 'indent', 'blocks', 'align', 'bidi' ] },
-        { name: 'links' },
-        { name: 'insert' },
-        '/',
-        { name: 'styles' },
-        { name: 'colors' },
-        { name: 'tools' },
-        { name: 'others' },
-        { name: 'about' }
-    ];
-    */
-
-    // This is the Serendipity tweaked toolbarGroups fallback, which does not need any extras manually filled in 'others', since done automatically by ckeditor.js or by the other named toolbars
+    
     config.toolbarGroups = [
         { name: 'styles' },
         { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },

--- a/htmlarea/ckeditor_s9y_plugin.js
+++ b/htmlarea/ckeditor_s9y_plugin.js
@@ -1,25 +1,15 @@
 /**
- * @fileOverview A Serendipity custom CKEDITOR additional plugin creator file:
- *               ckeditor_s9y_plugin.js, v. 1.4, last modified 2014-11-19, by Ian
- *
- * Please Note:  To use a custom plugin.js file, copy this file to templates/2k11/admin,
- *               or to your template in /templates/xxx/admin
- *               and rename it to ckeditor_custom_plugin.js.
+ * To use a custom plugin.js file, copy this file to templates/2k11/admin,
+ * or to your template in /templates/xxx/admin
+ * and rename it to ckeditor_custom_plugin.js.
  */
 
  // init custom button arrays
  var s9ypluginbuttons = [];
  var s9ymediabuttons = [];
 
- // Init CKEDITOR added plugins
- // Separate by comma, no whitespace allowed, and keep last comma, since later on concatenated with Serendipity hooked plugins, eg MediaLibrary!
- // For some CKEDITOR plugin you need the widget plugin, which is added here.
- //    Plugin Dependencies: widget      Add-on Dependencies: Line Utilities and Clipboard
- // mediaembed is a fast and simple YouTube code CKEditor-Plugin: v. 0.5+ (https://github.com/frozeman/MediaEmbed, 2013-09-12) to avoid ACF restrictions
- // procurator and cheatsheet are S9y only plugins
  var customplugins = 'mediaembed,procurator,cheatsheet,widget,dialog,codesnippet,';
 
- // for any new instance when it is created - listen on load
  CKEDITOR.on('instanceReady', function(evt){
 
     var editor = evt.editor,
@@ -28,9 +18,6 @@
         elements: {
             // for serendipity_event_imageselectorplus plugin galleries
             mediainsert: function( element ) {
-                // XHTML output instead of HTML - but this does not react on trailing slash eg <media "blah" />
-                // editor.dataProcessor.writer.selfClosingEnd = ' />';
-
                 // avoid line breaks with special block elements
                 var tags = ['mediainsert', 'gallery', 'media'];
 
@@ -51,7 +38,6 @@
                 }
             },
             // for S9y blog entry MediaLibrary added images
-            // Output dimensions of w/h images, since we either need an unchanged MediaLibrary image code for responsive templates or tweak some replacements!
             img: function( element ) {
                 var style = element.attributes.style;
 
@@ -66,8 +52,6 @@
                         element.attributes.style = element.attributes.style.replace( /(?:^|\s)height\s*:\s*(\d+)px;?/i , '' );
                         //element.attributes.height = height;
                         // Do not add to element attribute height, since then the height will be automatically (re-) added to style again by ckeditor or image js
-                        // The current result is now: img alt class src style{width}. That is the only working state to get around this issue in a relative simple way!
-                        // Remember: Turning ACF OFF, will leave code alone, but still removes the height="" attribute! (workaround in extraAllowedContent added img[height]!)
                     }
                 }
             }

--- a/include/functions_smarty.inc.php
+++ b/include/functions_smarty.inc.php
@@ -1039,18 +1039,17 @@ function serendipity_smarty_init($vars = array()) {
 
         if (defined('IN_serendipity_admin') && array_key_exists('wysiwyg', $serendipity) && $serendipity['wysiwyg']) {
 
-            // check force internal toolbar config file
+            // backwards compatibility with removed force-settings
             if (strpos($serendipity['wysiwygToolbar'], 'NOCC-') !== false) {
                 $serendipity['wysiwygToolbar'] = substr($serendipity['wysiwygToolbar'], 5);
-                $force_internal_toolbar = true;
             }
             // check ckeditor custom plugin file
             $ccp = serendipity_getTemplateFile('admin/ckeditor_custom_plugin.js', 'serendipityHTTPPath', true);
-            $wysiwyg_customPlugin = (!empty($ccp) && !$force_internal_toolbar) ? $ccp : $serendipity['serendipityHTTPPath'] . 'htmlarea/ckeditor_s9y_plugin.js';
+            $wysiwyg_customPlugin = (!empty($ccp)) ? $ccp : $serendipity['serendipityHTTPPath'] . 'htmlarea/ckeditor_s9y_plugin.js';
 
             // check ckeditor custom config file
             $ccc = serendipity_getTemplateFile('admin/ckeditor_custom_config.js', 'serendipityHTTPPath', true);
-            $wysiwyg_customConfig = (!empty($ccc) && !$force_internal_toolbar) ? $ccc : $serendipity['serendipityHTTPPath'] . 'htmlarea/ckeditor_s9y_config.js';
+            $wysiwyg_customConfig = (!empty($ccc)) ? $ccc : $serendipity['serendipityHTTPPath'] . 'htmlarea/ckeditor_s9y_config.js';
 
         }
 

--- a/include/tpl/config_personal.inc.php
+++ b/include/tpl/config_personal.inc.php
@@ -84,16 +84,7 @@
                                           'permission'  => 'personalConfiguration',
                                           'default'     => array(
                                               'Default'  => USERCONF_WYSIWYG_PRESET_S9Y,
-                                              'Basic'    => USERCONF_WYSIWYG_PRESET_BASIC,
                                               'Full'     => USERCONF_WYSIWYG_PRESET_FULL,
-                                              'Standard' => USERCONF_WYSIWYG_PRESET_STANDARD,
-                                              'CKE'      => USERCONF_WYSIWYG_PRESET_CKE,
-                                              '----',
-                                              'NOCC-Default'  => USERCONF_WYSIWYG_PRESET_NOCC_S9Y,
-                                              'NOCC-Basic'    => USERCONF_WYSIWYG_PRESET_NOCC_BASIC,
-                                              'NOCC-Full'     => USERCONF_WYSIWYG_PRESET_NOCC_FULL,
-                                              'NOCC-Standard' => USERCONF_WYSIWYG_PRESET_NOCC_STANDARD,
-                                              'NOCC-CKE'      => USERCONF_WYSIWYG_PRESET_NOCC_CKE
                                               ),
                                           'flags'       => array('config')),
 


### PR DESCRIPTION
We got clear feedback that the multitude of toolbar options is incomprehensible, with the force-* settings being not documented and completely unclear. This PR removes them and most of the toolbar options.

It keeps limited bc: The toolbar stays as is for users, until personal settings are saved again. It also cleans up the config files, and removes the code linked to the force-settings.