### PR TITLE
Hide PHP warnings in production mode

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,3 +1,5 @@
+   * Hide more PHP warnings in production mode, to ease the migration
+     to PHP 8
    * Fix: Deleting a user was not possible
    * New images added via the ML will set loading="lazy", improving
      site performance for visitors (only if height and width known)
@@ -11,7 +13,7 @@
    * Change backend_image_add hook to always contain same structure
    * Split date and time input in editor into two input fields
    * Improve performance of the media library by caching the file list
-
+   
 Version 2.4-alpha2 ()
 ------------------------------------------------------------------------
    * Adds 'image_id' to event 'backend_image_add' in addData array

--- a/include/plugin_api.inc.php
+++ b/include/plugin_api.inc.php
@@ -1305,12 +1305,18 @@ class serendipity_plugin_api
     static function load_language($path) {
         global $serendipity;
 
+        // We deactivate error reporting here, because in PHP 8 setting constants twice always throws a warning.
+        // However, the language files of some plugins sometimes rely on constants being set only in the fallback
+        // language file, so we do have to set the other constants twice.
+        $oldReportingLevel = error_reporting();
+        error_reporting(0);
+        
         $probelang = $path . '/' . $serendipity['charset'] . 'lang_' . $serendipity['lang'] . '.inc.php';
         if (file_exists($probelang)) {
             include $probelang;
-        } else {
-            include $path . '/lang_en.inc.php';
         }
+        include $path . '/lang_en.inc.php';
+        error_reporting($oldReportingLevel);
     }
 }
 

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -60,7 +60,11 @@ if (!isset($serendipity['production'])) {
 }
 
 // Set error reporting
-error_reporting(E_ALL & ~(E_NOTICE|E_STRICT|E_DEPRECATED)); // is 22519 with 5.4+
+if ($serendipity['production']) {
+    error_reporting(E_ALL & ~(E_WARNING|E_NOTICE|E_STRICT|E_DEPRECATED));
+} else {
+    error_reporting(E_ALL & ~(E_NOTICE|E_STRICT|E_DEPRECATED));
+}
 
 if ($serendipity['production'] !== true) {
     @ini_set('display_errors', 'on');


### PR DESCRIPTION
Serendipity works already with PHP 8, probably even without the changes I made during the last weeks. They mainly fight against the many warnings PHP is throwing now. So far, when s9y throws a PHP warning one of two things happens:

 1. In development mode, detemined by the version number including alpha-beta or set manually, execution stops. A warning becomes a full blown crash.
 2. In production mode the code continues, but the warning is printed at the top of the page.

What this change does is to hide the warnings only in production mode.

There is no chance we will succeed with fixing every plugin and theme until the end of the year, so that with PHP 8 they do not throw warnings. Not without a lot more support for that project. This is a stopgap solution to users can upgrade anyway and most likely continue using their old plugins and themes.