### PR TITLE
Fix more cases of unset  (php8 compatibility)

### DIFF
--- a/plugins/serendipity_plugin_syndication/serendipity_plugin_syndication.php
+++ b/plugins/serendipity_plugin_syndication/serendipity_plugin_syndication.php
@@ -212,10 +212,10 @@ class serendipity_plugin_syndication extends serendipity_plugin {
         if (serendipity_db_bool($this->get_config('show_2.0c', false)) || serendipity_db_bool($this->get_config('show_comment_feed', false))) {
             if ($useRss) {
                 echo $this->generateFeedButton( serendipity_rewriteURL(PATH_FEEDS .'/comments.rss2'),
-                                                $COMMENTS . ($useAtom ? " (RSS)": ""),
+                                                $COMMENTS . ((isset($useAtom) && $useAtom) ? " (RSS)": ""),
                                                 $small_icon);
             }
-            if ($useAtom) {
+            if (isset($useAtom) && $useAtom) {
                 echo $this->generateFeedButton( serendipity_rewriteURL(PATH_FEEDS .'/comments.atom10'),
                                                 $COMMENTS . ($useRss ? " (Atom)": ""),
                                                 $small_icon);

--- a/plugins/serendipity_plugin_syndication/serendipity_plugin_syndication.php
+++ b/plugins/serendipity_plugin_syndication/serendipity_plugin_syndication.php
@@ -13,7 +13,7 @@ class serendipity_plugin_syndication extends serendipity_plugin {
         $propbag->add('description',   SHOWS_RSS_BLAHBLAH);
         $propbag->add('stackable',     true);
         $propbag->add('author',        'Serendipity Team');
-        $propbag->add('version',       '2.3.0');
+        $propbag->add('version',       '2.3.1');
         $propbag->add('configuration', array(
                                         'title',
                                         'big_img',


### PR DESCRIPTION
The logs show warnings of "Undefined variable $useAtom" for lines 215/218 in serendipity_plugin_syndication.php. This fixes these, it's basically the same as
https://github.com/s9y/Serendipity/commit/a3253a0d5512c484d72df973c32e7f46e810bb28
just for two more uses of this variable.

Alternatively one could rework the logic at the beginning to make sure $useAtom is set to False and never undefined.