### PR TITLE
Encode square brackets in URL

### DIFF
--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -1236,10 +1236,10 @@ function serendipity_printEntries($entries, $extended = 0, $preview = false, $sm
             $entry['link_edit']              = $serendipity['baseURL'] .'serendipity_admin.php?serendipity[action]=admin&amp;serendipity[adminModule]=entries&amp;serendipity[adminAction]=edit&amp;serendipity[id]='. $entry['id'];
             $entry['link_trackback']         = $serendipity['baseURL'] .'comment.php?type=trackback&amp;entry_id='. $entry['id'];
             if (defined('VIEWMODE_THREADED')) {
-                $entry['link_viewmode_threaded'] = $serendipity['serendipityHTTPPath'] . $serendipity['indexFile'] .'?url='. $entry['commURL'] .'&amp;serendipity[cview]='. VIEWMODE_THREADED;
+                $entry['link_viewmode_threaded'] = $serendipity['serendipityHTTPPath'] . $serendipity['indexFile'] .'?url='. $entry['commURL'] .'&amp;serendipity%5Bcview%5D='. VIEWMODE_THREADED;
             }
             if (defined('VIEWMODE_LINEAR')) {
-                $entry['link_viewmode_linear']   = $serendipity['serendipityHTTPPath'] . $serendipity['indexFile'] .'?url='. $entry['commURL'] .'&amp;serendipity[cview]='. VIEWMODE_LINEAR;
+                $entry['link_viewmode_linear']   = $serendipity['serendipityHTTPPath'] . $serendipity['indexFile'] .'?url='. $entry['commURL'] .'&amp;serendipity%5Bcview%5D='. VIEWMODE_LINEAR;
             }
             $entry['link_author']            = serendipity_authorURL($authorData);
 


### PR DESCRIPTION
The W3C validator complains about the links containing [cview] (comment threading) in blog posts. This is due to the fact that [ and ] need to be url-encoded in href attributes. This PR fixes this.

See also this discussion on stackoverflow: https://stackoverflow.com/questions/40568/are-square-brackets-permitted-in-urls