### PR TITLE
Avoid trying to access session variable if it is not set

### DIFF
--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -25,7 +25,7 @@ class serendipity_event_spamblock extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '4.1.0'
         ));
-        $propbag->add('version',       '1.89.4');
+        $propbag->add('version',       '1.89.5');
         $propbag->add('event_hooks',    array(
             'frontend_saveComment' => true,
             'external_plugin'      => true,

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -1305,7 +1305,7 @@ class serendipity_event_spamblock extends serendipity_event
 
                     if ($show_captcha) {
                         echo '<div class="serendipity_commentDirection serendipity_comment_captcha">';
-                        if (!isset($serendipity['POST']['preview']) || strtolower($serendipity['POST']['captcha'] != strtolower($_SESSION['spamblock']['captcha']))) {
+                        if (!isset($serendipity['POST']['preview']) || !isset($_SESSION['spamblock']['captcha']) || strtolower($serendipity['POST']['captcha'] != strtolower($_SESSION['spamblock']['captcha']))) {
                             echo '<br />' . PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_USERDESC . '<br />';
                             echo $this->show_captcha($use_gd);
                             echo '<br />';


### PR DESCRIPTION
 This avoid warnings if a user tries to solve a captcha without an active PHP session (e.g. because Cookies are disabled).

I regularly observed warnings like this in my logs:
```
PHP Warning:  Undefined array key "spamblock" in [path]/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php on line 1308
[25-Nov-2022 17:35:52 Europe/Berlin] PHP Warning:  Trying to access array offset on value of type null in  [path]/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php on line 1308
```

The issue is that the captcha code compares the entered captcha to a session variable. I assume this is triggered by spambots that don't have cookies enabled, but it can also be reproduced by disabling cookies in Firefox for a domain and trying to enter a comment with a captcha form.

The patch does not change the behavior (the user will get a warning about the missing session), but avoids the two warnings.