### PR TITLE
add simple CI pipeline with basic PHP test runner

### DIFF
--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -33,8 +33,7 @@ jobs:
         coverage: none
       env:
         fail-fast: true
-    - name: Check that PHP works
-      shell: php {0}
+    - name: Run Tests
       run: |
-        <?php
-        echo "Hello world from PHP " . PHP_VERSION;    
+        cd tests
+        phpunit --configuration config.xml.dist --coverage-html report include/*

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -1,0 +1,40 @@
+# This workflow will run the tests on various versions of PHP.
+
+name: PHP Tests
+
+on:
+  push:
+  pull_request:
+    types: [opened]
+# TODO: enable to run once a week regardless of commits, but this will expire if repo is inactive for a longer time
+#  schedule:
+#    - cron: '12 3 4 * *'
+
+jobs:
+  test-php:
+    name: Run PHP Tests
+
+    runs-on: ubuntu-22.04
+
+    # for available versions see https://github.com/marketplace/actions/setup-php-action#tada-php-support
+    strategy:
+      matrix:
+        phpversion: ['8.1', '8.2', '8.3']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup PHP and dependencies
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.phpversion }}
+        extensions: pdo-sqlite
+        tools: phpunit
+        # TODO: enable coverage check
+        coverage: none
+      env:
+        fail-fast: true
+    - name: Check that PHP works
+      shell: php {0}
+      run: |
+        <?php
+        echo "Hello world from PHP " . PHP_VERSION;    

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -19,7 +19,7 @@ jobs:
     # for available versions see https://github.com/marketplace/actions/setup-php-action#tada-php-support
     strategy:
       matrix:
-        phpversion: ['8.1', '8.2', '8.3']
+        phpversion: ['7.4', '8.1', '8.2', '8.3']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/php_tests.yml
+++ b/.github/workflows/php_tests.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run Tests
       run: |
         cd tests
-        phpunit --configuration config.xml.dist --coverage-html report include/*
+        phpunit --configuration config.xml.dist include/*

--- a/tests/config.xml.dist
+++ b/tests/config.xml.dist
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit>
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="false">
-      <directory>../include</directory>
-      <directory>../plugins</directory>
-        <exclude>
-          <file>../include/db/mysql.inc.php</file>
-          <file>../include/db/mysqli.inc.php</file>
-          <file>../include/db/pdo-postgres.inc.php</file>
-          <file>../include/db/postgres.inc.php</file>
-          <file>../include/db/mysql.inc.php</file>
-          <file>../include/db/sqlrelay.inc.php</file>
-        </exclude>
-    </whitelist>
-  </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <php>
     <var name="S9Y_INSTALLDIR" value="http://localhost/s9y"/>
     <var name="S9Y_LANG" value="en"/>
@@ -23,4 +8,18 @@
     <var name="S9Y_SELENIUM_PORT" value="4444"/>
     <var name="S9Y_SELENIUM_BROWSER" value="*firefox /usr/lib/firefox/firefox-bin"/>
   </php>
+  <source>
+    <include>
+      <directory>../include</directory>
+      <directory>../plugins</directory>
+    </include>
+    <exclude>
+      <file>../include/db/mysql.inc.php</file>
+      <file>../include/db/mysqli.inc.php</file>
+      <file>../include/db/pdo-postgres.inc.php</file>
+      <file>../include/db/postgres.inc.php</file>
+      <file>../include/db/mysql.inc.php</file>
+      <file>../include/db/sqlrelay.inc.php</file>
+    </exclude>
+  </source>
 </phpunit>

--- a/tests/include/functionsConfigTest.php
+++ b/tests/include/functionsConfigTest.php
@@ -22,11 +22,11 @@ class functionsConfigTest extends PHPUnit\Framework\TestCase
         $serendipity['template_backend'] = '2k11';
         $serendipity['serendipityPath'] = realpath('../');
         $serendipity['serendipityHTTPPath'] = realpath('/');
-        
-        $this->assertContains('next/index.tpl', serendipity_getTemplateFile('index.tpl'));
+
+        $this->assertStringEndsWith('next/index.tpl', serendipity_getTemplateFile('index.tpl'));
         define('IN_serendipity_admin', true);
-        $this->assertContains('2k11/admin/index.tpl', serendipity_getTemplateFile('admin/index.tpl'));
-        $this->assertContains('next/index.tpl', serendipity_getTemplateFile('index.tpl', 'serendipityHTTPPath', true));
+        $this->assertStringEndsWith('2k11/admin/index.tpl', serendipity_getTemplateFile('admin/index.tpl'));
+        $this->assertStringEndsWith('next/index.tpl', serendipity_getTemplateFile('index.tpl', 'serendipityHTTPPath', true));
     }
 
 }

--- a/tests/include/functionsConfigTest.php
+++ b/tests/include/functionsConfigTest.php
@@ -4,14 +4,14 @@ $serendipity['dbType'] = 'pdo-sqlite';
 define('IN_serendipity', true);
 require_once dirname(__FILE__) . '/../../include/functions_config.inc.php';
 
+use PHPUnit\Framework\Attributes\Test;
+
 /**
  * Class functionsTest
  */
 class functionsConfigTest extends PHPUnit\Framework\TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function test_serendipity_getTemplateFile()
     {
         global $serendipity;
@@ -28,6 +28,5 @@ class functionsConfigTest extends PHPUnit\Framework\TestCase
         $this->assertContains('2k11/admin/index.tpl', serendipity_getTemplateFile('admin/index.tpl'));
         $this->assertContains('next/index.tpl', serendipity_getTemplateFile('index.tpl', 'serendipityHTTPPath', true));
     }
-
 
 }

--- a/tests/include/functionsConfigTest.php
+++ b/tests/include/functionsConfigTest.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__) . '/../../include/functions_config.inc.php';
 /**
  * Class functionsTest
  */
-class functionsConfigTest extends PHPUnit_Framework_TestCase
+class functionsConfigTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/include/functionsTest.php
+++ b/tests/include/functionsTest.php
@@ -5,15 +5,16 @@ define('IN_serendipity', true);
 define('S9Y_INCLUDE_PATH', dirname(__FILE__) . '/../../');
 require_once dirname(__FILE__) . '/../../include/functions.inc.php';
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
 /**
  * Class functionsTest
  */
 class functionsTest extends PHPUnit\Framework\TestCase
 {
-    /**
-     * @test
-     * @dataProvider serverOffsetHourDataProvider
-     */
+    #[Test]
+    #[DataProvider("serverOffsetHourDataProvider")]
     public function test_serendipity_serverOffsetHour($serverOffsetHours, $timestamp, $negative, $expected)
     {
         global $serendipity;
@@ -39,10 +40,8 @@ class functionsTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @test
-     * @dataProvider serverOffsetHourWithTimestampNullDataProvider
-     */
+    #[Test]
+    #[DataProvider("serverOffsetHourWithTimestampNullDataProvider")]
     public function test_serendipity_serverOffsetHourWithTimestampNull($serverOffsetHours, $negative)
     {
         global $serendipity;

--- a/tests/include/functionsTest.php
+++ b/tests/include/functionsTest.php
@@ -25,7 +25,7 @@ class functionsTest extends PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function serverOffsetHourDataProvider()
+    public static function serverOffsetHourDataProvider()
     {
         return array(
             array(0, 0, false, 0),
@@ -63,7 +63,7 @@ class functionsTest extends PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function serverOffsetHourWithTimestampNullDataProvider()
+    public static function serverOffsetHourWithTimestampNullDataProvider()
     {
         return array(
             array(null, false),

--- a/tests/include/functionsTest.php
+++ b/tests/include/functionsTest.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__) . '/../../include/functions.inc.php';
 /**
  * Class functionsTest
  */
-class functionsTest extends PHPUnit_Framework_TestCase
+class functionsTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/include/functionsTest.php
+++ b/tests/include/functionsTest.php
@@ -2,6 +2,7 @@
 
 $serendipity['dbType'] = 'pdo-sqlite';
 define('IN_serendipity', true);
+define('S9Y_INCLUDE_PATH', dirname(__FILE__) . '/../../');
 require_once dirname(__FILE__) . '/../../include/functions.inc.php';
 
 /**

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,28 +1,24 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<phpunit bootstrap="bootstrap.php"
-         backupGlobals="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         colors="true">
-    <php>
-        <const name="IN_serendipity" value="true"/>
-        <!--<const name="IS_installed" value="true"/>-->
-        <!--<const name="USERLEVEL_ADMIN" value="255"/>-->
-        <!--<const name="USERLEVEL_CHIEF" value="1"/>-->
-        <!--<const name="USERLEVEL_EDITOR" value="0"/>-->
-        <!--<const name="DB_DSN" value="sqlite:dbname=s9y_test;host=localhost" />-->
-        <!--<const name="DB_HOST" value="localhost" />-->
-        <!--<const name="DB_TYPE" value="pdo-sqlite" />-->
-        <!--<const name="DB_USER" value="s9y_test" />-->
-        <!--<const name="DB_PASSWD" value="s9y_test" />-->
-        <!--<const name="DB_DBNAME" value="s9y_test" />-->
-        <!--<const name="TEST_DB" value="test.db" />-->
-        <!--<const name="PATH_SMARTY_COMPILE" value="templates_c" />-->
-    </php>
-    <testsuites>
-        <testsuite name="include">
-            <directory>../tests/include</directory>
-        </testsuite>
-    </testsuites>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="bootstrap.php" backupGlobals="true" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <php>
+    <const name="IN_serendipity" value="true"/>
+    <!--<const name="IS_installed" value="true"/>-->
+    <!--<const name="USERLEVEL_ADMIN" value="255"/>-->
+    <!--<const name="USERLEVEL_CHIEF" value="1"/>-->
+    <!--<const name="USERLEVEL_EDITOR" value="0"/>-->
+    <!--<const name="DB_DSN" value="sqlite:dbname=s9y_test;host=localhost" />-->
+    <!--<const name="DB_HOST" value="localhost" />-->
+    <!--<const name="DB_TYPE" value="pdo-sqlite" />-->
+    <!--<const name="DB_USER" value="s9y_test" />-->
+    <!--<const name="DB_PASSWD" value="s9y_test" />-->
+    <!--<const name="DB_DBNAME" value="s9y_test" />-->
+    <!--<const name="TEST_DB" value="test.db" />-->
+    <!--<const name="PATH_SMARTY_COMPILE" value="templates_c" />-->
+  </php>
+  <testsuites>
+    <testsuite name="include">
+      <directory>../tests/include</directory>
+    </testsuite>
+  </testsuites>
+  <source/>
 </phpunit>


### PR DESCRIPTION
(ping @garvinhicking ref. https://www.onli-blogging.de/2323/15-Jahre-Serendipity-als-Entwickler-ein-Rueckblick-und-ein-Ausblick.html#c10436)

I have prepared a simple GitHub Action CI pipeline that runs the basic PHP tests on every push and will annotate commits and Pull Requests with the build status.

The tests run for all current PHP versions (that means 8.1, 8.2 and 8.3). The matrix can be expanded to other versions as well, but I don't know if we need to test against deprecated PHP versions without security support. On the other hand, nightly builds of PHP 8.4 could also be used as a test target.

To make the tests pass I had to update them to make them work with a current version of PHPUnit.

Things currently not included:
* There is no build status badge for `README.markdown` yet. If you like to have one, I'll add it :-)
* Code coverage is not computed yet. With the low count of test cases this does not seem too useful at the moment.
* `FrontendTest.php` is not included yet. The test framework _Selenium RC_ is triple-deprecated (Selenium RC is Selenium 1; Selenium 1, 2 and 3 are already deprecated; Selenium 4 is current) and I can't even find downloads of the mentioned `selenium-server.jar` (Selenium homepage and GitHub project offer Selenium 2.39.0 as oldest download). I'll see if I can update the tests to work with a current version somehow or if it is feasible to switch to another test framework (any wishes?) - but not as part of this PR ;-)


