### PR TITLE
bugfix: Made comment token clean-up work in PostgreSQL also

### DIFF
--- a/include/db/db.inc.php
+++ b/include/db/db.inc.php
@@ -183,4 +183,21 @@ function serendipity_db_implode($string, &$array, $type = 'int') {
     return $string;
 }
 
+/**
+ * @access public
+ * @param   string Database table column name
+ * @param   string Database column type
+ * @return  string Column CAST() to chosen database
+ */
+function serendipity_db_cast($columnName, $type) {
+    global $serendipity;
+
+    if (stristr($serendipity['dbType'], 'sqlite')) {
+        return $columnName;
+    }
+
+    // Adds explicits casting for ANSI SQL -compliant DBs, like mysql and postgresql.
+    return "cast($columnName as $type)";
+}
+
 /* vim: set sts=4 ts=4 expandtab : */

--- a/include/db/db.inc.php
+++ b/include/db/db.inc.php
@@ -196,6 +196,12 @@ function serendipity_db_cast($columnName, $type) {
         return $columnName;
     }
 
+    // MySQL (and variants) have unsigned integer. ANSI SQL does not.
+    if ($type == 'unsigned') {
+        if (!stristr($serendipity['dbType'], 'mysqli'))
+            $type = 'integer';
+    }
+
     // Adds explicits casting for ANSI SQL -compliant DBs, like mysql and postgresql.
     return "cast($columnName as $type)";
 }

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -20,8 +20,9 @@ function serendipity_checkCommentToken($token, $cid) {
     $goodtoken = false;
     if ($serendipity['useCommentTokens']) {
         // Delete any comment tokens older than 1 week.
+        $oneWeekAgo = time() - 604800;
         serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}options
-                              WHERE okey LIKE 'comment_%' AND name < " . (time() - 604800) );
+                              WHERE okey LIKE 'comment_%' AND name < '{$oneWeekAgo}'");
         // Get the token for this comment id
         $tokencheck = serendipity_db_query("SELECT * FROM {$serendipity['dbPrefix']}options
                                              WHERE okey = 'comment_" . (int)$cid . "' LIMIT 1", true, 'assoc');
@@ -1229,8 +1230,9 @@ function serendipity_generateCToken($cid) {
     $ctoken = bin2hex(random_bytes(16));
     
         //Delete any comment tokens older than 1 week.
+        $oneWeekAgo = time() - 604800;
         serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}options
-                              WHERE okey LIKE 'comment_%' AND name < " . (time() - 604800) );
+                              WHERE okey LIKE 'comment_%' AND name < '{$oneWeekAgo}'");
 
         // Issue new comment moderation hash
         serendipity_db_query("INSERT INTO {$serendipity['dbPrefix']}options (name, value, okey)


### PR DESCRIPTION
SQL-table _options_ has column _name_ defined as varchar.
https://github.com/s9y/Serendipity/blob/master/sql/db.sql#L182

In code, the cleanup calculates an unix timestamp pointing to history one week ago. This interger is then compared with the mentioned varchar in SQL. This comparison might fly on some RDMSes, on PostgreSQL typing is strict and an int cannot be compared with a varchar.

This commit fixes the problem making comment handling working again.