### PR TITLE
Block .inc files in .htaccess template

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -7,6 +7,8 @@ Version 2.6-alpha1 ()
    * Fix token cleanup SQL statement in PostgreSQL environments
      (thanks to HQJaTu Jari Turkia)
 
+   * Block access to .inc php files via .htaccess
+
 Version 2.5.0 (February 13th, 2024)
 ------------------------------------------------------------------------
 

--- a/include/tpl/htaccess_cgi_errordocs.tpl
+++ b/include/tpl/htaccess_cgi_errordocs.tpl
@@ -22,4 +22,8 @@ DirectoryIndex {PREFIX}{indexFile}
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_cgi_normal.tpl
+++ b/include/tpl/htaccess_cgi_normal.tpl
@@ -21,4 +21,8 @@ DirectoryIndex {PREFIX}{indexFile}
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_cgi_rewrite.tpl
+++ b/include/tpl/htaccess_cgi_rewrite.tpl
@@ -52,4 +52,8 @@ RewriteRule (.*\.html?) {indexFile}?url=/$1 [L,QSA]
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_cgi_rewrite2.tpl
+++ b/include/tpl/htaccess_cgi_rewrite2.tpl
@@ -51,4 +51,8 @@ RewriteRule (.*\.html?) {indexFile}?url=/$1 [L,QSA]
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_errordocs.tpl
+++ b/include/tpl/htaccess_errordocs.tpl
@@ -22,4 +22,8 @@ DirectoryIndex {PREFIX}{indexFile}
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_normal.tpl
+++ b/include/tpl/htaccess_normal.tpl
@@ -21,4 +21,8 @@ DirectoryIndex {PREFIX}{indexFile}
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_rewrite.tpl
+++ b/include/tpl/htaccess_rewrite.tpl
@@ -52,4 +52,8 @@ RewriteRule (.*\.html?) {indexFile}?url=/$1 [L,QSA]
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y

--- a/include/tpl/htaccess_rewrite2.tpl
+++ b/include/tpl/htaccess_rewrite2.tpl
@@ -51,4 +51,8 @@ RewriteRule (.*\.html?) {indexFile}?url=/$1 [L,QSA]
     deny from all
 </Files>
 
+<Files *.inc>
+    deny from all
+</Files> 
+
 # END s9y


### PR DESCRIPTION
Blocking .inc files might be seen as a security feature, for webserver configurations that execute files with that ending.