### PR TITLE
Show older entries & drafts first

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,5 +1,7 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
+   * Swap order of entries in the dashboard, so that upcoming
+     entries are shown first
 
    * Set more efficient defaults for (jpg) thumbnail generation
 

--- a/include/admin/overview.inc.php
+++ b/include/admin/overview.inc.php
@@ -108,7 +108,7 @@ $entries = serendipity_fetchEntries(
                      (int)$serendipity['dashboardEntriesLimit'],
                      true,
                      false,
-                     'timestamp DESC',
+                     'timestamp ASC',
                      'e.timestamp >= ' . serendipity_serverOffsetHour() . $efilter
                    );
 
@@ -124,7 +124,7 @@ if ($entriesAmount < (int)$serendipity['dashboardEntriesLimit']) {
                      (int)$serendipity['dashboardEntriesLimit'] - $entriesAmount,
                      true,
                      false,
-                     'timestamp DESC',
+                     'timestamp ASC',
                      "isdraft = 'true' AND e.timestamp <= " . serendipity_serverOffsetHour() . $efilter
                    );
     if (is_array($entries) && is_array($drafts)) {


### PR DESCRIPTION
I propose this change to the dashboard. The entry box currently shows the newest scheduled entries and drafts first. For future entries, that means the ones which are furthest in the future.  As a result, if you have more than the 5 entries shown you you don't see the next upcoming entries anymore. I think this is the wrong way around, at least for scheduled entries: The entries which are closest to the current date (the oldest) are the more useful ones, as is is those that I'd reread or edit first after logging in. This PR changes the entry order accordingly, older drafts and scheduled entries are shown first.

I'm pretty convinced for scheduled entries it's better this way, for drafts I'm less sure. I changed those for consistency. We could also split them up into separate lists.