### PR TITLE
serendipity_sendMail: terminate headers with CRLF.

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -20,6 +20,9 @@ Version 2.6-alpha1 ()
 
    * Block access to .inc php files via .htaccess
 
+   * Make serendipity_sendMail() standard compliant by using CRLF
+     instead of LF to separate headers.
+
 Version 2.5.0 (February 13th, 2024)
 ------------------------------------------------------------------------
 

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -564,7 +564,7 @@ function serendipity_sendMail($to, $subject, $message, $fromMail, $headers = NUL
     }
 
     if (!isset($maildata['skip_native']) && !empty($maildata['to'])) {
-        return mail($maildata['to'], $maildata['subject'], $maildata['message'], implode("\n", $maildata['headers']));
+        return mail($maildata['to'], $maildata['subject'], $maildata['message'], implode("\r\n", $maildata['headers']));
     }
 }
 


### PR DESCRIPTION
serendipity_sendMail() will concatenate additional headers to a string separated with LF (\n). That is not standard compliant, as RFC 5322 demands CRLF (\r\n).

This has real life implications at least on PHP 8.2.20 with Exim 4.96, as all additional headers are appended to one single long header line, losing encoding information and more.

Change LF to CRLF here.

Fixes #852.