### PR TITLE
bugfix: pg_escape_string() in serendipity_db_escape_string() works again

### DIFF
--- a/include/admin/maintenance.inc.php
+++ b/include/admin/maintenance.inc.php
@@ -65,7 +65,7 @@ switch($serendipity['GET']['adminAction']) {
 
 
 $data['maintenance_mode'] = serendipity_db_bool(serendipity_get_config_var("maintenanceMode", false));
-$data['maintenance_mode_end'] = strftime('%d.%m.%y %T', serendipity_get_config_var("maintenanceModeEnd"));
+$data['maintenance_mode_end'] = date('j.n.Y e', serendipity_get_config_var("maintenanceModeEnd"));
 $data['maintenance_mode_active'] = $data['maintenance_mode'] && time() < serendipity_get_config_var("maintenanceModeEnd", 0);
 
 # php 8 compat section

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -94,6 +94,11 @@ function serendipity_db_escape_string($string) {
     if (is_null($string))
         return $string;
 
+    if (PHP_MAJOR_VERSION < 8 || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 1))
+        # Last supported version is PHP 8.0
+        return pg_escape_string($string);
+
+    # From PHP 8.1 onwards
     return pg_escape_string($serendipity['dbConn'], $string);
 }
 

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -89,7 +89,9 @@ function serendipity_db_reconnect() {
  * @return  string   output string
  */
 function serendipity_db_escape_string($string) {
-    return pg_escape_string($string);
+    global $serendipity;
+
+    return pg_escape_string($serendipity['dbConn'], $string);
 }
 
 /**

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -94,9 +94,10 @@ function serendipity_db_escape_string($string) {
     if (is_null($string))
         return $string;
 
-    if (PHP_MAJOR_VERSION < 8 || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 1))
-        # Last supported version is PHP 8.0
+    if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+        # Versions before 8.1 give the connection by default
         return pg_escape_string($string);
+    }
 
     # From PHP 8.1 onwards
     return pg_escape_string($serendipity['dbConn'], $string);

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -91,6 +91,9 @@ function serendipity_db_reconnect() {
 function serendipity_db_escape_string($string) {
     global $serendipity;
 
+    if (is_null($string))
+        return $string;
+
     return pg_escape_string($serendipity['dbConn'], $string);
 }
 

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -1390,12 +1390,15 @@ function serendipity_updertEntry($entry) {
 
     serendipity_plugin_api::hook_event('backend_entry_presave', $entry);
 
-    $categories = $entry['categories'];
+    $categories = $entry['categories'] ?? null;
     unset($entry['categories']);
 
     if (array_key_exists('had_categories', $entry)) {
         $had_categories = $entry['had_categories'];
         unset($entry['had_categories']);        
+    }
+    else {
+        $had_categories = null;
     }
 
     $newEntry = 0;
@@ -1414,7 +1417,7 @@ function serendipity_updertEntry($entry) {
         $entry['extended'] = '';
     }
 
-    if (strlen($entry['extended'])) {
+    if (isset($entry['extended']) && strlen($entry['extended'])) {
         $exflag = 1;
     }
 

--- a/include/functions_permalinks.inc.php
+++ b/include/functions_permalinks.inc.php
@@ -10,11 +10,15 @@ if (IN_serendipity !== true) {
  * Converts a string into a filename that can be used safely in HTTP URLs
  *
  * @access public
- * @param   string  input string
+ * @param   string  input string|null
  * @param   boolean Shall dots in the filename be removed? (Required for certain regex rules)
- * @return  string  output string
+ * @return  string  output string|null
  */
 function serendipity_makeFilename($str, $stripDots = false) {
+
+    if (is_null($str)) {
+        return $str;
+    }
 
     // These are UTF-8 replacements happening regardless of selected locale
     static $pre_from = array(

--- a/plugins/serendipity_event_entryproperties/serendipity_event_entryproperties.php
+++ b/plugins/serendipity_event_entryproperties/serendipity_event_entryproperties.php
@@ -878,7 +878,8 @@ class serendipity_event_entryproperties extends serendipity_event
                         }
                     }
 
-                    if ($addData['preview'] && is_array($serendipity['POST']['properties']) && count($serendipity['POST']['properties']) > 0){
+                    if ($addData['preview'] && isset($serendipity['POST']['properties']) &&
+                        is_array($serendipity['POST']['properties']) && count($serendipity['POST']['properties']) > 0){
                         $parr = array();
                         $supported_properties = serendipity_event_entryproperties::getSupportedProperties();
                         foreach($supported_properties AS $prop_key) {

--- a/templates/2k11/admin/overview.inc.tpl
+++ b/templates/2k11/admin/overview.inc.tpl
@@ -88,7 +88,7 @@
                     <ul class="plainList actions">
                         <li><a class="button_link" href="?serendipity[action]=admin&amp;serendipity[adminModule]=entries&amp;serendipity[adminAction]=preview&amp;{$urltoken}&amp;serendipity[id]={$entry.id}" title="{$CONST.PREVIEW} #{$entry.id}"><span class="icon-search" aria-hidden="true"></span><span class="visuallyhidden"> {$CONST.PREVIEW}</span></a></li>
                         <li><a class="button_link" href="?serendipity[action]=admin&amp;serendipity[adminModule]=entries&amp;serendipity[adminAction]=edit&amp;serendipity[id]={$entry.id}" title="{$CONST.EDIT} #{$entry.id}"><span class="icon-edit" aria-hidden="true"></span><span class="visuallyhidden"> {$CONST.EDIT}</span></a></li>
-                        {if $entry.isdraft == "true"}
+                        {if $entry.isdraft[0] == "t"}
                             <li>
                                 <form method="POST" class="overviewListForm">
                                     <input type="hidden" name="serendipity[adminAction]" value="publish" />
@@ -100,13 +100,13 @@
                         {/if}
 
                     </ul>
-                {if !$showFutureEntries && ($entry.timestamp >= $serverOffsetHour) && $entry.isdraft == "false"}
+                {if !$showFutureEntries && ($entry.timestamp >= $serverOffsetHour) && $entry.isdraft[0] == "f"}
                     <span class="entry_status status_future" title="{$CONST.SCHEDULED}: {$CONST.ENTRY_PUBLISHED_FUTURE}">{$entry.timestamp|formatTime:$CONST.DATE_FORMAT_SHORT}</span>
                 {/if}
                 {if isset($entry.properties.ep_is_sticky) && $entry.properties.ep_is_sticky}
                     <span class="entry_status status_sticky">{$CONST.STICKY_POSTINGS}</span>
                 {/if}
-                {if $entry.isdraft == "true"}
+                {if $entry.isdraft[0] == "t"}
                     <span class="entry_status status_draft">{$CONST.DRAFT}</span>
                 {/if}
                 </li>


### PR DESCRIPTION
Docs: https://www.php.net/manual/en/function.pg-escape-string.php

In PHP 8.1+ there is no default connection. A mandatory connection must be given as a parameter. This PR restores PostgreSQL support for S9y.

Not sure if PHP <8.1 must be supported. If yes, PHP_MAJOR_VERSION and PHP_MINOR_VERSION could be checked to determine which interface of `pg_escape_string()` needs to be used.