### PR TITLE
Bugfix: Using PHP 8.2 dynamic properties removed

### DIFF
--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -89,7 +89,9 @@ function serendipity_db_reconnect() {
  * @return  string   output string
  */
 function serendipity_db_escape_string($string) {
-    return pg_escape_string($string);
+    global $serendipity;
+
+    return pg_escape_string($serendipity['dbConn'], $string);
 }
 
 /**

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -91,6 +91,9 @@ function serendipity_db_reconnect() {
 function serendipity_db_escape_string($string) {
     global $serendipity;
 
+    if (is_null($string))
+        return $string;
+
     return pg_escape_string($serendipity['dbConn'], $string);
 }
 

--- a/plugins/serendipity_event_bbcode/serendipity_event_bbcode.php
+++ b/plugins/serendipity_event_bbcode/serendipity_event_bbcode.php
@@ -9,6 +9,8 @@ if (IN_serendipity !== true) {
 class serendipity_event_bbcode extends serendipity_event
 {
     var $title = PLUGIN_EVENT_BBCODE_NAME;
+    protected $markup_elements = array();
+
     function introspect(&$propbag)
     {
         global $serendipity;

--- a/plugins/serendipity_event_templatechooser/serendipity_event_templatechooser.php
+++ b/plugins/serendipity_event_templatechooser/serendipity_event_templatechooser.php
@@ -9,6 +9,7 @@ if (IN_serendipity !== true) {
 class serendipity_event_templatechooser extends serendipity_event
 {
     var $title = PLUGIN_EVENT_TEMPLATECHOOSER_NAME;
+    protected $dependencies = array();
 
     function introspect(&$propbag)
     {

--- a/plugins/serendipity_event_textile/serendipity_event_textile.php
+++ b/plugins/serendipity_event_textile/serendipity_event_textile.php
@@ -9,6 +9,7 @@ if (IN_serendipity !== true) {
 class serendipity_event_textile extends serendipity_event
 {
     var $title = PLUGIN_EVENT_TEXTILE_NAME;
+    protected $markup_elements = array();
 
     function introspect(&$propbag)
     {
@@ -251,7 +252,7 @@ class serendipity_event_textile extends serendipity_event
                 '<font color="',
                 '</font>',
                 "\n ",
-                'Ê '
+                'ï¿½ '
             ),
             array(
                 ' ',

--- a/plugins/serendipity_event_xhtmlcleanup/serendipity_event_xhtmlcleanup.php
+++ b/plugins/serendipity_event_xhtmlcleanup/serendipity_event_xhtmlcleanup.php
@@ -10,6 +10,7 @@ class serendipity_event_xhtmlcleanup extends serendipity_event
 {
     var $title = PLUGIN_EVENT_XHTMLCLEANUP_NAME;
     var $cleanup_tag, $cleanup_checkfor, $cleanup_val, $cleanup_parse;
+    protected $markup_elements = array();
 
     function introspect(&$propbag)
     {

--- a/plugins/serendipity_plugin_creativecommons/serendipity_plugin_creativecommons.php
+++ b/plugins/serendipity_plugin_creativecommons/serendipity_plugin_creativecommons.php
@@ -9,6 +9,7 @@ if (IN_serendipity !== true) {
 class serendipity_plugin_creativecommons extends serendipity_plugin
 {
     var $title = PLUGIN_SIDEBAR_CREATIVECOMMONS_NAME;
+    protected $dependencies = array();
 
     function introspect(&$propbag)
     {

--- a/plugins/serendipity_plugin_templatedropdown/serendipity_plugin_templatedropdown.php
+++ b/plugins/serendipity_plugin_templatedropdown/serendipity_plugin_templatedropdown.php
@@ -9,6 +9,7 @@ if (IN_serendipity !== true) {
 class serendipity_plugin_templatedropdown extends serendipity_plugin
 {
     var $title = PLUGIN_TEMPLATEDROPDOWN_NAME;
+    protected $dependencies = array();
 
     function introspect(&$propbag)
     {


### PR DESCRIPTION
PHP 8.2 removes support of dynamic class properties. Compensate the change on selected plugins.

While looking at those changes a pattern emerges.
Maybe having `$markup_elements` and `$dependencies` in parent class should be a faster and cleaner fix. While at it drop usage of way-back-obsoleted `let`.