### PR TITLE
Limit integrated searchbox to 2k11 (#797)

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Fix an often broken element of old themes by not adding the
+     integrated search box when 2k11 is used as the default theme
+
    * Fix specific search terms (like a - at the end) causing an error
      page when using MySQL/MariaDB (thanks to  GuillaumeValadas) 
 

--- a/templates/2k11/index.tpl
+++ b/templates/2k11/index.tpl
@@ -46,7 +46,7 @@
                 {if $blogDescription}<p>{$blogDescription}</p>{/if}
             </a>
         </div>
-
+        {if $template == "2k11"}
         <form id="searchform" action="{$serendipityHTTPPath}{$serendipityIndexFile}" method="get">
         <div>
             <input type="hidden" name="serendipity[action]" value="search">
@@ -56,6 +56,7 @@
         </div>
         </form>
         {serendipity_hookPlugin hook="quicksearch_plugin" hookAll="true"}
+        {/if}
         {if $template_option.header_img}
         <img src="{$template_option.header_img|escape}" alt="">
         {/if}

--- a/templates/2k11/sidebar.tpl
+++ b/templates/2k11/sidebar.tpl
@@ -2,7 +2,7 @@
 <div id="serendipity{$pluginside}SideBar">
 {/if}
 {foreach from=$plugindata item=item}
-{if $item.class != "serendipity_plugin_quicksearch"}
+{if $item.class != "serendipity_plugin_quicksearch" || $template != "2k11"}
     <section class="sidebar_plugin clearfix {cycle values="odd,even"} {$item.class}">
         {if $item.title != ""}
         <h3>{$item.title}</h3>


### PR DESCRIPTION
Fixes old themes, by making it possible to use the quicksearch plugin and not having to add styles for the integrated searchbox. All includes new themes won't be affected since they have their own index.tpl.