### PR TITLE
Remove & reference declaration from db_query to avoid warning

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,5 +1,7 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
+   * Avoid PHP 8 warning about incurrect reference return of db_query
+     function
 
    * Fix option to set a different theme as fallback option by setting
      Engine: $themename in a themes info.txt

--- a/include/db/mysqli.inc.php
+++ b/include/db/mysqli.inc.php
@@ -58,7 +58,7 @@ function serendipity_db_in_sql($col, &$search_ids, $type = ' OR ') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignored on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
     global $serendipity;
     $type_map = array('assoc' => MYSQLI_ASSOC, 'num' => MYSQLI_NUM, 'both' => MYSQLI_BOTH, 'true' => true, 'false' => false);
 

--- a/include/db/pdo-postgres.inc.php
+++ b/include/db/pdo-postgres.inc.php
@@ -199,7 +199,7 @@ function serendipity_db_insert_id($table = '', $id = '') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignroed on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
     global $serendipity;
     $type_map = array(
                          'assoc' => PDO::FETCH_ASSOC,

--- a/include/db/pdo-sqlite.inc.php
+++ b/include/db/pdo-sqlite.inc.php
@@ -215,7 +215,7 @@ function serendipity_db_insert_id($table = '', $id = '') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignroed on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
     global $serendipity;
     $type_map = array(
                          'assoc' => PDO::FETCH_ASSOC,

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -203,7 +203,7 @@ function serendipity_db_insert_id($table = '', $id = '') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignroed on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
     global $serendipity;
     $type_map = array(
                          'assoc' => PGSQL_ASSOC,

--- a/include/db/sqlite.inc.php
+++ b/include/db/sqlite.inc.php
@@ -209,7 +209,7 @@ function serendipity_db_in_sql($col, &$search_ids, $type = ' OR ') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignored on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = true, $assocKey = false, $assocVal = false, $expectError = false)
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = true, $assocKey = false, $assocVal = false, $expectError = false)
 {
     global $serendipity;
     $type_map = array(

--- a/include/db/sqlite3.inc.php
+++ b/include/db/sqlite3.inc.php
@@ -218,7 +218,7 @@ function serendipity_db_in_sql($col, &$search_ids, $type = ' OR ') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignroed on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = true, $assocKey = false, $assocVal = false, $expectError = false)
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = true, $assocKey = false, $assocVal = false, $expectError = false)
 {
     global $serendipity;
     $type_map = array(

--- a/include/db/sqlite3oo.inc.php
+++ b/include/db/sqlite3oo.inc.php
@@ -224,7 +224,7 @@ function serendipity_db_in_sql($col, &$search_ids, $type = ' OR ') {
  * @param   boolean     If true, the executed SQL error is known to fail, and should be disregarded (errors can be ignroed on DUPLICATE INDEX queries and the likes)
  * @return  mixed       Returns the result of the SQL query, depending on the input parameters
  */
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = true, $assocKey = false, $assocVal = false, $expectError = false)
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = true, $assocKey = false, $assocVal = false, $expectError = false)
 {
     global $serendipity;
     $type_map = array(

--- a/include/db/sqlrelay.inc.php
+++ b/include/db/sqlrelay.inc.php
@@ -113,7 +113,7 @@ function generate_resultset($cursor, $result_type = 'sqlr_BOTH') {
    return $return_row;
 }
 
-function &serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
+function serendipity_db_query($sql, $single = false, $result_type = "both", $reportErr = false, $assocKey = false, $assocVal = false, $expectError = false) {
     global $serendipity;
     $type_map = array(
                          'assoc' => sqlr_ASSOC,

--- a/include/functions_config.inc.php
+++ b/include/functions_config.inc.php
@@ -305,12 +305,12 @@ function serendipity_load_configuration($author = null) {
 
     if (!empty($author)) {
         // Replace default configuration directives with user-relevant data
-        $rows =& serendipity_db_query("SELECT name,value
+        $rows = serendipity_db_query("SELECT name,value
                                         FROM {$serendipity['dbPrefix']}config
                                         WHERE authorid = '". (int)$author ."'");
     } else {
         // Only get default variables, user-independent (frontend)
-        $rows =& serendipity_db_query("SELECT name, value
+        $rows = serendipity_db_query("SELECT name, value
                                         FROM {$serendipity['dbPrefix']}config
                                         WHERE authorid = 0");
     }
@@ -550,7 +550,7 @@ function serendipity_authenticate_author($username = '', $password = '', $is_has
                     username   = '" . serendipity_db_escape_string($username) . "'";
         if ($debug) fwrite($fp, date('Y-m-d H:i') . ' - Login check (' . serialize($is_hashed) . ', ' . $_SESSION['serendipityPassword'] . '):' . $query . "\n");
 
-        $rows =& serendipity_db_query($query, false, 'assoc');
+        $rows = serendipity_db_query($query, false, 'assoc');
         if (is_array($rows)) {
             $is_valid_user = false;
             foreach($rows AS $row) {
@@ -1117,7 +1117,7 @@ function &serendipity_getPermissions($authorid) {
     global $serendipity;
 
         // Get group information
-        $groups =& serendipity_db_query("SELECT ag.groupid, g.name, gc.property, gc.value
+        $groups = serendipity_db_query("SELECT ag.groupid, g.name, gc.property, gc.value
                                           FROM {$serendipity['dbPrefix']}authorgroups AS ag
                                LEFT OUTER JOIN {$serendipity['dbPrefix']}groups AS g
                                             ON ag.groupid = g.id
@@ -1340,7 +1340,7 @@ function &serendipity_getAllGroups($apply_ACL_user = false) {
     global $serendipity;
 
     if ($apply_ACL_user) {
-        $groups =& serendipity_db_query("SELECT g.id   AS confkey,
+        $groups = serendipity_db_query("SELECT g.id   AS confkey,
                                                 g.name AS confvalue,
                                                 g.id   AS id,
                                                 g.name AS name
@@ -1350,7 +1350,7 @@ function &serendipity_getAllGroups($apply_ACL_user = false) {
                                           WHERE ag.authorid = " . (int)$apply_ACL_user . "
                                        ORDER BY g.name", false, 'assoc');
     } else {
-        $groups =& serendipity_db_query("SELECT g.id   AS confkey,
+        $groups = serendipity_db_query("SELECT g.id   AS confkey,
                                                 g.name AS confvalue,
                                                 g.id   AS id,
                                                 g.name AS name
@@ -1378,7 +1378,7 @@ function &serendipity_fetchGroup($groupid) {
     global $serendipity;
 
     $conf = array();
-    $groups =& serendipity_db_query("SELECT g.id        AS confkey,
+    $groups = serendipity_db_query("SELECT g.id        AS confkey,
                                             g.name      AS confvalue,
                                             g.id        AS id,
                                             g.name      AS name,
@@ -1416,7 +1416,7 @@ function &serendipity_fetchGroup($groupid) {
 function &serendipity_getGroups($authorid, $sequence = false) {
     global $serendipity;
 
-    $_groups =& serendipity_db_query("SELECT g.id  AS confkey,
+    $_groups = serendipity_db_query("SELECT g.id  AS confkey,
                                             g.name AS confvalue,
                                             g.id   AS id,
                                             g.name AS name
@@ -1452,7 +1452,7 @@ function &serendipity_getGroups($authorid, $sequence = false) {
 function &serendipity_getGroupUsers($groupid) {
     global $serendipity;
 
-    $groups =& serendipity_db_query("SELECT g.name     AS name,
+    $groups = serendipity_db_query("SELECT g.name     AS name,
                                             a.realname AS author,
                                             a.authorid AS id
                                       FROM {$serendipity['dbPrefix']}authorgroups AS ag
@@ -1523,7 +1523,7 @@ function serendipity_addGroup($name) {
 function &serendipity_getDBPermissionNames() {
     global $serendipity;
 
-    $config =& serendipity_db_query("SELECT property FROM {$serendipity['dbPrefix']}groupconfig GROUP BY property ORDER BY property", false, 'assoc');
+    $config = serendipity_db_query("SELECT property FROM {$serendipity['dbPrefix']}groupconfig GROUP BY property ORDER BY property", false, 'assoc');
 
     return $config;
 }
@@ -1809,7 +1809,7 @@ function serendipity_ACLGet($artifact_id, $artifact_type, $artifact_mode, $artif
                       AND artifact_id    = '" . (int)$artifact_id . "'
                       AND artifact_mode  = '" . serendipity_db_escape_string($artifact_mode) . "'
                       AND artifact_index = '" . serendipity_db_escape_string($artifact_index) . "'";
-    $rows =& serendipity_db_query($sql, false, 'assoc');
+    $rows = serendipity_db_query($sql, false, 'assoc');
 
     if (!is_array($rows)) {
         return false;
@@ -1870,7 +1870,7 @@ function serendipity_ACLCheck($authorid, $artifact_id, $artifact_type, $artifact
                AND ( {$artifact_sql['where']} )
           GROUP BY result";
 
-    $res =& serendipity_db_query($sql, true, 'assoc');
+    $res = serendipity_db_query($sql, true, 'assoc');
     if (is_array($res) && !empty($res['result'])) {
         return true;
     }
@@ -2132,7 +2132,7 @@ function &serendipity_loadThemeOptions(&$template_config, $okey = '', $bc_bool =
         $okey = $serendipity['template'];
     }
 
-    $_template_vars =& serendipity_db_query("SELECT name, value FROM {$serendipity['dbPrefix']}options
+    $_template_vars = serendipity_db_query("SELECT name, value FROM {$serendipity['dbPrefix']}options
                                              WHERE okey = 't_" . serendipity_db_escape_string($okey) . "'
                                                 OR okey = 't_global'", false, 'assoc', false, 'name', 'value');
     if (!is_array($_template_vars)) {

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -36,7 +36,7 @@ function serendipity_deleteCategory($category_range, $admin_category) {
 function serendipity_fetchCategoryRange($categoryid) {
     global $serendipity;
 
-    $res =& serendipity_db_query("SELECT category_left, category_right, hide_sub FROM {$serendipity['dbPrefix']}category WHERE categoryid='". (int)$categoryid ."'");
+    $res = serendipity_db_query("SELECT category_left, category_right, hide_sub FROM {$serendipity['dbPrefix']}category WHERE categoryid='". (int)$categoryid ."'");
     if (!is_array($res) || !isset($res[0]['category_left']) || !isset($res[0]['category_right'])) {
         $res = array(array('category_left' => 0, 'category_right' => 0));
     }
@@ -103,7 +103,7 @@ function serendipity_fetchCategoryInfo($categoryid, $categoryname = '') {
                     FROM {$serendipity['dbPrefix']}category AS c
                    WHERE category_name = '" . serendipity_db_escape_string($categoryname) . "'";
 
-        $ret =& serendipity_db_query($query);
+        $ret = serendipity_db_query($query);
         return $ret[0];
     } else {
         $query = "SELECT
@@ -117,7 +117,7 @@ function serendipity_fetchCategoryInfo($categoryid, $categoryname = '') {
                     FROM {$serendipity['dbPrefix']}category AS c
                    WHERE categoryid = " . (int)$categoryid;
 
-        $ret =& serendipity_db_query($query);
+        $ret = serendipity_db_query($query);
         return $ret[0];
     }
 }
@@ -145,7 +145,7 @@ function &serendipity_fetchEntryCategories($entryid) {
                    WHERE ec.entryid = {$entryid}
                 ORDER BY c.category_name ASC";
 
-        $cat =& serendipity_db_query($query,false,'assoc');
+        $cat = serendipity_db_query($query,false,'assoc');
         
         if (!is_array($cat)) {
             $arr = array();
@@ -487,7 +487,7 @@ function &serendipity_fetchEntries($range = null, $full = true, $limit = '', $fe
         return $query;
     }
 
-    $ret =& serendipity_db_query($query, $fetch_single, 'assoc');
+    $ret = serendipity_db_query($query, $fetch_single, 'assoc');
 
     if (is_string($ret)) {
         die("Query failed: $ret");
@@ -550,7 +550,7 @@ function serendipity_fetchEntryData(&$ret) {
                WHERE " . serendipity_db_in_sql('ec.entryid', $search_ids) . "
             ORDER BY c.category_name ASC";
 
-    $search_ret =& serendipity_db_query($query, false, 'assoc');
+    $search_ret = serendipity_db_query($query, false, 'assoc');
 
     if (is_array($search_ret)) {
         serendipity_plugin_api::hook_event('multilingual_strip_langs', $search_ret, array('category_name','category_description'));
@@ -630,7 +630,7 @@ function &serendipity_fetchEntry($key, $val, $full = true, $fetchDrafts = 'false
                             {$cond['single_orderby']}
                      LIMIT  1";
 
-    $ret =& serendipity_db_query($querystring, true, 'assoc');
+    $ret = serendipity_db_query($querystring, true, 'assoc');
 
     if (is_array($ret)) {
         $ret['categories'] =& serendipity_fetchEntryCategories($ret['id']);
@@ -657,7 +657,7 @@ function &serendipity_fetchEntryProperties($id) {
     $parts = array();
     serendipity_plugin_api::hook_event('frontend_entryproperties_query', $parts);
 
-    $_properties =& serendipity_db_query("SELECT property, value FROM {$serendipity['dbPrefix']}entryproperties WHERE entryid = " . (int)$id . " " . $parts['and']);
+    $_properties = serendipity_db_query("SELECT property, value FROM {$serendipity['dbPrefix']}entryproperties WHERE entryid = " . (int)$id . " " . $parts['and']);
     if (!is_array($_properties)) {
         $properties = array();
     } else {
@@ -767,7 +767,7 @@ function &serendipity_fetchCategories($authorid = null, $name = null, $order = n
         $querystring .= "\n ORDER BY $order";
     }
 
-    $ret =& serendipity_db_query($querystring);
+    $ret = serendipity_db_query($querystring);
     if (is_string($ret)) {
         echo "Query failed: $ret";
     } else {
@@ -950,7 +950,7 @@ function &serendipity_searchEntries($term, $limit = '', $searchresults = '') {
                   ORDER BY  {$cond['searchorderby']}
                     $limit";
 
-    $search =& serendipity_db_query($querystring);
+    $search = serendipity_db_query($querystring);
 
     //Add param searchresults at the top and remove duplicates.
     if (is_array($searchresults)) {
@@ -1059,7 +1059,7 @@ function serendipity_getTotalEntries() {
     if ($serendipity['fullCountQuery'] == '') {
         return 0;
     }
-    $query =& serendipity_db_query($querystring);
+    $query = serendipity_db_query($querystring);
 
     if (is_array($query) && isset($query[0])) {
         if ($serendipity['dbType'] == 'sqlite' || $serendipity['dbType'] == 'sqlite3' || $serendipity['dbType'] == 'pdo-sqlite' || $serendipity['dbType'] == 'sqlite3oo') {
@@ -1758,7 +1758,7 @@ function serendipity_printArchives() {
                 . (!empty($serendipity['GET']['viewAuthor']) ? ' AND e.authorid = ' . (int)$serendipity['GET']['viewAuthor'] : '')
                 . (!empty($cat_sql) ? " GROUP BY e.id, e.timestamp" : '');
     
-    $entries =& serendipity_db_query($q, false, 'assoc');
+    $entries = serendipity_db_query($q, false, 'assoc');
 
     $group = array();
     if (is_array($entries)) {

--- a/include/plugin_api.inc.php
+++ b/include/plugin_api.inc.php
@@ -1754,7 +1754,7 @@ class serendipity_plugin
      * @param   string  The path selector that tells whether to return a HTTP or realpath
      * @return  string  The full path+filename to the requested file
      * */
-    function &getFile($filename, $key = 'serendipityPath')
+    function getFile($filename, $key = 'serendipityPath')
     {
         global $serendipity;
         


### PR DESCRIPTION
Also adjusts the code that calls the function with a prepended &, as that would have caused a new warning. Fixes #848.