### PR TITLE
Replace (int) parser conversion with spl_object_hash

### DIFF
--- a/bundled-libs/XML/RPC.php
+++ b/bundled-libs/XML/RPC.php
@@ -245,7 +245,7 @@ function XML_RPC_se($parser_resource, $name, $attrs)
 {
     global $XML_RPC_xh, $XML_RPC_valid_parents;
 
-    $parser = (int) $parser_resource;
+    $parser = spl_object_hash($parser_resource);
 
     // if invalid xmlrpc already detected, skip all processing
     if ($XML_RPC_xh[$parser]['isf'] >= 2) {
@@ -374,7 +374,7 @@ function XML_RPC_ee($parser_resource, $name)
 {
     global $XML_RPC_xh;
 
-    $parser = (int) $parser_resource;
+    $parser = spl_object_hash($parser_resource);
 
     if ($XML_RPC_xh[$parser]['isf'] >= 2) {
         return;
@@ -511,7 +511,7 @@ function XML_RPC_cd($parser_resource, $data)
 {
     global $XML_RPC_xh, $XML_RPC_backslash;
 
-    $parser = (int) $parser_resource;
+    $parser = spl_object_hash($parser_resource);
 
     if ($XML_RPC_xh[$parser]['lv'] != 3) {
         // "lookforvalue==3" means that we've found an entire value
@@ -1433,7 +1433,7 @@ class XML_RPC_Message extends XML_RPC_Base
 
         $encoding = $this->getEncoding($data);
         $parser_resource = xml_parser_create($encoding);
-        $parser = 1;
+        $parser = spl_object_hash($parser_resource);
 
         $XML_RPC_xh = array();
         $XML_RPC_xh[$parser] = array();


### PR DESCRIPTION
The (int) conversion does not work anymore since PHP 8 changed the xml parser from being a resource to being an object. Hardcoding it to a number, the initial fix, destroys the logic of having multiple parsers available and was not done everywhere. The object hash approach should be a valid replacement.

Draft, as still to be tested.