### PR TITLE
gravatar 2.0: Fix gravatar, remove twitter and identica

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,10 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Update bundled avatar plugin: Fix gravatar image fetching, remove
+     defunct options for identica and twitter avatars, and clean up
+     documentation,
+
    * PHP 8.4 fix: Remove deprecated constant E_STRICT
 
    * PHP 8 compatibility fixes for bundled XML/RPC.php

--- a/plugins/serendipity_event_gravatar/ChangeLog
+++ b/plugins/serendipity_event_gravatar/ChangeLog
@@ -1,3 +1,12 @@
+Version 2.0:
+------------------------------------------------------------------------
+    * Fix gravatar: Avatars could not be fetched
+    * Remove the defunct avatar options identica and twitter
+    * Reimplement favatar and pavatar options for better reliability
+    * Update wavatar generator
+    * Update documentation and translation
+    * Additional fixes for PH 8 compatibility
+
 Version 1.63.1:
 ------------------------------------------------------------------------
     * PHP 8 compatibility

--- a/plugins/serendipity_event_gravatar/LICENSE
+++ b/plugins/serendipity_event_gravatar/LICENSE
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_cs.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_cs.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona či obrázek přispěvatele) v komentářích. Podporovány jsou služby Gravatar, Pavatar, Favatar a MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona či obrázek přispěvatele) v komentářích. Podporovány jsou služby Gravatar, Pavatar a Favatar.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Tvořit smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Pokud je tato volba zapnuta, obrázky avatarů nejsou zapsány přímo do textu komentáře, ale je místo toho vygenerován tag {$comment.avatar} pro šablonovací systém smarty. Pak budou avatary zobrazovat pouze styly vzhledu, které tento tag používají. Nejjednodušší způsob, jak zjistit, jestli Váš styl vzhledu podporuje avatary, je vyzkoušet zapnout toto nastavení.');
@@ -51,10 +51,9 @@
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatar</a></b> je centrální úložiště obrázků uživatelů spřažené s emailovou adresou, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatar</a></b> poskytuje favicony načtené z osobních stránek uživatele, <b><a href="http://www.pavatar.com" target="_blank">Pavatar</a></b> ' .
-        'jsou obrázky uložené na osobních stránkách pisatele, <b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatar</a></b> jsou centrálně ukládané obrázky a ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> a <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> avatary jsou nahrávané obrázky vytvořené jednotlivými uživateli.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">POZOR!</font> Tento plugin musí být zařazen před všemi pluginy, které mění odkazy (jako např. plugin "exit tracking plugin")! ' .
-        '<font color="red">Jinak nebudou pracovat avatary služeb Pavatar, Favatar a MayBlogLog!</font>');
+        '<font color="red">Jinak nebudou pracovat avatary služeb Pavatar a Favatar!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Gravatar fallback');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar má implementovaných několik návratových metod pro případ, že pro požadovaného uživatele není znám žádný avatar. Implementovány jsou též Moster ID, Identicon a Wavatar. Pokud vyberete některý z těchto zíněných, nebudou uskutečňovány žádné další pokusy o načtení avataru, pokud uživatel zadá email.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_cz.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_cz.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona či obrázek přispěvatele) v komentářích. Podporovány jsou služby Gravatar, Pavatar, Favatar a MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona či obrázek přispěvatele) v komentářích. Podporovány jsou služby Gravatar, Pavatar a Favatar.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Tvořit smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Pokud je tato volba zapnuta, obrázky avatarů nejsou zapsány přímo do textu komentáře, ale je místo toho vygenerován tag {$comment.avatar} pro šablonovací systém smarty. Pak budou avatary zobrazovat pouze styly vzhledu, které tento tag používají. Nejjednodušší způsob, jak zjistit, jestli Váš styl vzhledu podporuje avatary, je vyzkoušet zapnout toto nastavení.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
@@ -49,9 +49,9 @@
 @define('PLUGIN_EVENT_GRAVATAR_AUTOR_ALT_DESC',     'Normaler Weise wird der Autorenname im TITLE Attribut des Avatar Bildes angegeben, das ALT Attribut wird mit einem * gefüllt, um das Seitenlayout nicht zu zerstören, wenn der Browser das Bild nicht laden kann. Allerdings wird blinden Lesern das ALT Attribut vorgelesen. Falls Sie diese Leser unterstützen wollen, sollten Sie diese Option einschalten.');
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
-        '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
-        '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
-        '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');
+        '<b>Favatare</b> sind die Favicons auf der Homepage, die der Kommentator angegeben hat, ' .
+        '<b><a href="http://pavatar.github.io/pavatar/" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
+        '<b><a href="https://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="https://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ACHTUNG!</font> Dieses Plugin muss vor allen Plugins ausgeführt werden, die Links verändern (wie z.B. das Exit Tracking Plugin)!<br/>' .
         '<font color="red">Ansonsten werden Pavatare und Favatare nicht funktionieren!</font>');
 

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare und MyBlogLog Avatare');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare und Alternativen wie Favatare.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Smarty Tag erzeugen');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Wenn diese Option eingeschaltet ist, so wird das Avatar Bild nicht direkt in den Kommentar geschrieben, sondern es wird ein Smarty Tag {$comment.avatar} erzeugt, in dem der HTML Code des Images steht. Sie sollten diese Option nur einschalten, wenn sie wissen, dass ihr Template dieses Smarty Tag unterstützt. Ob das der Fall ist, sollten sie einfach ausprobieren.');
@@ -51,10 +51,9 @@
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
-        '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog Avatare</a></b> werden von einem zentralen Server geladen und ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ACHTUNG!</font> Dieses Plugin muss vor allen Plugins ausgeführt werden, die Links verändern (wie z.B. das Exit Tracking Plugin)!<br/>' .
-        '<font color="red">Ansonsten werden Pavatare, Favatare und MyBlogLog Avatare nicht funktionieren!</font>');
+        '<font color="red">Ansonsten werden Pavatare und Favatare nicht funktionieren!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Gravatar Fallback');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar implementiert einige eigene Fallback Methoden für den Fal, dass kein Gravatar für den Benutzer gefunden wurde. Es wurde ebenso Moster ID, Identicon und Wavatar. Wenn Du einen dieser Fallbacks einstellst, so wird keine weitere Methode nach Gravatar versucht, falls der Benutzer eine EMail angegeben hat.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare, Twitter, Identica und MyBlogLog Avatare');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare, Twitter und MyBlogLog Avatare');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Smarty Tag erzeugen');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Wenn diese Option eingeschaltet ist, so wird das Avatar Bild nicht direkt in den Kommentar geschrieben, sondern es wird ein Smarty Tag {$comment.avatar} erzeugt, in dem der HTML Code des Images steht. Sie sollten diese Option nur einschalten, wenn sie wissen, dass ihr Template dieses Smarty Tag unterstützt. Ob das der Fall ist, sollten sie einfach ausprobieren.');
@@ -51,7 +51,6 @@
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
         '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> lädt Bilder aus Twitter Profilen, ' .
-        '<b><a href="http://identi.ca" target="_blank">Identica</a></b> lädt Bilder aus Identica Profilen, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog Avatare</a></b> werden von einem zentralen Server geladen und ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_de.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare, Twitter und MyBlogLog Avatare');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare und MyBlogLog Avatare');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Smarty Tag erzeugen');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Wenn diese Option eingeschaltet ist, so wird das Avatar Bild nicht direkt in den Kommentar geschrieben, sondern es wird ein Smarty Tag {$comment.avatar} erzeugt, in dem der HTML Code des Images steht. Sie sollten diese Option nur einschalten, wenn sie wissen, dass ihr Template dieses Smarty Tag unterstützt. Ob das der Fall ist, sollten sie einfach ausprobieren.');
@@ -50,7 +50,6 @@
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
-        '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> lädt Bilder aus Twitter Profilen, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog Avatare</a></b> werden von einem zentralen Server geladen und ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_pl.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_pl.inc.php
@@ -7,7 +7,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Pokazuje avatary w komentarzach. Gravatars, Pavatars, Favatars und MyBlogLog avatars are supported.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Pokazuje avatary w komentarzach.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Produce smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'If this option is switched on, the avatar images are not written directly into the comment output but a smarty tag {$comment.avatar} is produced. Only templates, that support this smarty tag, will display the avatar, if this option is set to true. The best way is to try it, if your template supports this smarty tag.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_ru.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_ru.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Плагин аватаров');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar, Twitter, Identica и MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar, Twitter и MyBlogLog.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Создать тег Smarty');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Если эта опция включена, изображения аватара не записываются непосредственно в вывод комментария, но создаётся тег smarty {$comment.avatar}. Только шаблоны, поддерживающие этот тег Smarty, будут отображать аватар, если для этой опции установлено значение "Да". Лучший способ - попробовать это, если Ваш шаблон поддерживает этот тег Smarty.');
@@ -46,7 +46,6 @@
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatar</a></b> являются иконками сайта (favicon) писателя, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatar</a></b> являются изображениями на сайте автора, ' .
         '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> загружает изображения профиля в Twitter, ' .
-        '<b><a href="http://identi.ca" target="_blank">Identica</a></b> загружает изображения профиля identi.ca, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">Аватары MyBlogLog</a></b> снова являются централизованными изображениями аватаров и ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> и <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> являются локально созданными изображениями монстров, уникальными для каждого автора.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ОСТОРОЖНО!</font> Этот плагин должен быть запущен перед любым плагином, изменяющим ссылки (например, плагин отслеживания выхода)! ' .

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_ru.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_ru.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Плагин аватаров');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar, Twitter и MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar и MyBlogLog.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Создать тег Smarty');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Если эта опция включена, изображения аватара не записываются непосредственно в вывод комментария, но создаётся тег smarty {$comment.avatar}. Только шаблоны, поддерживающие этот тег Smarty, будут отображать аватар, если для этой опции установлено значение "Да". Лучший способ - попробовать это, если Ваш шаблон поддерживает этот тег Smarty.');

--- a/plugins/serendipity_event_gravatar/UTF-8/lang_ru.inc.php
+++ b/plugins/serendipity_event_gravatar/UTF-8/lang_ru.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Плагин аватаров');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar и MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar и Favatar');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Создать тег Smarty');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Если эта опция включена, изображения аватара не записываются непосредственно в вывод комментария, но создаётся тег smarty {$comment.avatar}. Только шаблоны, поддерживающие этот тег Smarty, будут отображать аватар, если для этой опции установлено значение "Да". Лучший способ - попробовать это, если Ваш шаблон поддерживает этот тег Smarty.');

--- a/plugins/serendipity_event_gravatar/documentation_de.html
+++ b/plugins/serendipity_event_gravatar/documentation_de.html
@@ -18,8 +18,6 @@
     <li><a href="#avt_gravatar">Gravatar</a></li>
     <li><a href="#avt_pavatar">Pavatar</a></li>
     <li><a href="#avt_favatar">Favatar</a></li>
-    <li><a href="#avt_twitter">Twitter</a></li>
-    <li><a href="#avt_identica">Identica</a></li>
     <li><a href="#avt_mybloglog">MyBlogLog</a></li>
     <li><a href="#avt_wavatar">Wavatar</a></li>
     <li><a href="#avt_monsterid">MonsterID</a></li>
@@ -72,18 +70,6 @@
 <h3>Favatar</h3>
 <p>Dies ist ein Konzept mit dem viele Hompage Besitzer automatisch einen Avatar haben, ohne dass sie dafür irgendetwas tun müssen:</p>
 <p>Das Blog holt sich hier einfach das favicon der Homepage, die der Benutzer als seine URL angegeben hat. Dafür ist das favicon aber eben ein Icon und somit normaler Weise auch recht klein und nicht immer als Avatar geeignet.</p>
-<p><a href="#top">top</a></p>
-
-<a name="avt_twitter"></a>
-<h3>Twitter</h3>
-<p>Falls der Kommentator als URL ein <a href="http://twitter.com" target="_blank">Twitter Profil</a> angegeben hat, dann wird versucht, hier das Profilbild für diesen Benutzer zu laden.</p>
-<p><i>Anmerkung</i>: Falls auch Favatare geladen werden sollen, dann muss Twitter vor diesen versucht werden, sonst wird das Favicon von Twitter geladen. Dies kann allerdings auch gewollt sein, um z.B. "Tweetbacks" von Twitter klar zu markieren.</p>
-<p><a href="#top">top</a></p>
-
-<a name="avt_identica"></a>
-<h3>Identica</h3>
-<p>Dies ist ein spezielles Avatar für <a href="http://identi.ca" target="_blank">Identica</a> Pingbacks. Es wird versucht, das Profilbild des Benutzers zu laden, der den Pingback ausgelöst hat.</p>
-<p><i>Anmerkung</i>: Falls auch Favatare geladen werden sollen, dann muss Identica vor diesen versucht werden, sonst wird das Favicon von Identica geladen. Dies kann allerdings auch gewollt sein, um z.B. "Tweetbacks" von Identica klar zu markieren.</p>
 <p><a href="#top">top</a></p>
 
 <a name="avt_mybloglog"></a>

--- a/plugins/serendipity_event_gravatar/documentation_de.html
+++ b/plugins/serendipity_event_gravatar/documentation_de.html
@@ -18,7 +18,6 @@
     <li><a href="#avt_gravatar">Gravatar</a></li>
     <li><a href="#avt_pavatar">Pavatar</a></li>
     <li><a href="#avt_favatar">Favatar</a></li>
-    <li><a href="#avt_mybloglog">MyBlogLog</a></li>
     <li><a href="#avt_wavatar">Wavatar</a></li>
     <li><a href="#avt_monsterid">MonsterID</a></li>
     <li><a href="#avt_identicon">Identicon/YCon</a></li>
@@ -70,12 +69,6 @@
 <h3>Favatar</h3>
 <p>Dies ist ein Konzept mit dem viele Hompage Besitzer automatisch einen Avatar haben, ohne dass sie dafür irgendetwas tun müssen:</p>
 <p>Das Blog holt sich hier einfach das favicon der Homepage, die der Benutzer als seine URL angegeben hat. Dafür ist das favicon aber eben ein Icon und somit normaler Weise auch recht klein und nicht immer als Avatar geeignet.</p>
-<p><a href="#top">top</a></p>
-
-<a name="avt_mybloglog"></a>
-<h3>MyBlogLog</h3>
-<p>Dies ist wieder ein (dem Gravatar Service sehr ähnlicher) zentraler Service. MyBlogLog ist eigentlich ein Blog Community Service, aber man kann aus diesem ebenfalls Avatare ermitteln</p>
-<p>Das Vorhandensein eines MyBlogLog Avatars wird über die Homepage Angabe des Kommentators ermittelt.</p>
 <p><a href="#top">top</a></p>
 
 <a name="avt_wavatar"></a>

--- a/plugins/serendipity_event_gravatar/lang_cs.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_cs.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona èi obrázek pøispìvatele) v komentáøích. Podporovány jsou služby Gravatar, Pavatar, Favatar a MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona èi obrázek pøispìvatele) v komentáøích. Podporovány jsou služby Gravatar, Pavatar a Favatar.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Tvoøit smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Pokud je tato volba zapnuta, obrázky avatarù nejsou zapsány pøímo do textu komentáøe, ale je místo toho vygenerován tag {$comment.avatar} pro šablonovací systém smarty. Pak budou avatary zobrazovat pouze styly vzhledu, které tento tag používají. Nejjednodušší zpùsob, jak zjistit, jestli Váš styl vzhledu podporuje avatary, je vyzkoušet zapnout toto nastavení.');
@@ -51,10 +51,9 @@
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatar</a></b> je centrální úložištì obrázkù uživatelù spøažené s emailovou adresou, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatar</a></b> poskytuje favicony naètené z osobních stránek uživatele, <b><a href="http://www.pavatar.com" target="_blank">Pavatar</a></b> ' .
-        'jsou obrázky uložené na osobních stránkách pisatele, <b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatar</a></b> jsou centrálnì ukládané obrázky a ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> a <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> avatary jsou nahrávané obrázky vytvoøené jednotlivými uživateli.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">POZOR!</font> Tento plugin musí být zaøazen pøed všemi pluginy, které mìní odkazy (jako napø. plugin "exit tracking plugin")! ' .
-        '<font color="red">Jinak nebudou pracovat avatary služeb Pavatar, Favatar a MayBlogLog!</font>');
+        '<font color="red">Jinak nebudou pracovat avatary služeb Pavatar a Favatar!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Gravatar fallback');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar má implementovaných nìkolik návratových metod pro pøípad, že pro požadovaného uživatele není znám žádný avatar. Implementovány jsou též Moster ID, Identicon a Wavatar. Pokud vyberete nìkterý z tìchto zínìných, nebudou uskuteèòovány žádné další pokusy o naètení avataru, pokud uživatel zadá email.');

--- a/plugins/serendipity_event_gravatar/lang_cz.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_cz.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona èi obrázek pøispìvatele) v komentáøích. Podporovány jsou slu¾by Gravatar, Pavatar, Favatar a MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Zobrazuje avatary (ikona èi obrázek pøispìvatele) v komentáøích. Podporovány jsou slu¾by Gravatar, Pavatar a Favatar.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Tvoøit smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Pokud je tato volba zapnuta, obrázky avatarù nejsou zapsány pøímo do textu komentáøe, ale je místo toho vygenerován tag {$comment.avatar} pro ¹ablonovací systém smarty. Pak budou avatary zobrazovat pouze styly vzhledu, které tento tag pou¾ívají. Nejjednodu¹¹í zpùsob, jak zjistit, jestli Vá¹ styl vzhledu podporuje avatary, je vyzkou¹et zapnout toto nastavení.');
@@ -51,10 +51,9 @@
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatar</a></b> je centrální úlo¾i¹tì obrázkù u¾ivatelù spøa¾ené s emailovou adresou, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatar</a></b> poskytuje favicony naètené z osobních stránek u¾ivatele, <b><a href="http://www.pavatar.com" target="_blank">Pavatar</a></b> ' .
-        'jsou obrázky ulo¾ené na osobních stránkách pisatele, <b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatar</a></b> jsou centrálnì ukládané obrázky a ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> a <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> avatary jsou nahrávané obrázky vytvoøené jednotlivými u¾ivateli.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">POZOR!</font> Tento plugin musí být zaøazen pøed v¹emi pluginy, které mìní odkazy (jako napø. plugin "exit tracking plugin")! ' .
-        '<font color="red">Jinak nebudou pracovat avatary slu¾eb Pavatar, Favatar a MayBlogLog!</font>');
+        '<font color="red">Jinak nebudou pracovat avatary slu¾eb Pavatar a Favatar!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Gravatar fallback');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar má implementovaných nìkolik návratových metod pro pøípad, ¾e pro po¾adovaného u¾ivatele není znám ¾ádný avatar. Implementovány jsou té¾ Moster ID, Identicon a Wavatar. Pokud vyberete nìkterý z tìchto zínìných, nebudou uskuteèòovány ¾ádné dal¹í pokusy o naètení avataru, pokud u¾ivatel zadá email.');

--- a/plugins/serendipity_event_gravatar/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_de.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare und MyBlogLog Avatare');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare und Alternativen wie Favatare.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Smarty Tag erzeugen');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Wenn diese Option eingeschaltet ist, so wird das Avatar Bild nicht direkt in den Kommentar geschrieben, sondern es wird ein Smarty Tag {$comment.avatar} erzeugt, in dem der HTML Code des Images steht. Sie sollten diese Option nur einschalten, wenn sie wissen, dass ihr Template dieses Smarty Tag unterstützt. Ob das der Fall ist, sollten sie einfach ausprobieren.');
@@ -51,10 +51,9 @@
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
-        '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog Avatare</a></b> werden von einem zentralen Server geladen und ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ACHTUNG!</font> Dieses Plugin muss vor allen Plugins ausgeführt werden, die Links verändern (wie z.B. das Exit Tracking Plugin)!<br/>' .
-        '<font color="red">Ansonsten werden Pavatare, Favatare und MyBlogLog Avatare nicht funktionieren!</font>');
+        '<font color="red">Ansonsten werden Pavatare und Favatare nicht funktionieren!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Gravatar Fallback');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar implementiert einige eigene Fallback Methoden für den Fal, dass kein Gravatar für den Benutzer gefunden wurde. Es wurde ebenso Moster ID, Identicon und Wavatar. Wenn Du einen dieser Fallbacks einstellst, so wird keine weitere Methode nach Gravatar versucht, falls der Benutzer eine EMail angegeben hat.');

--- a/plugins/serendipity_event_gravatar/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_de.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare, Twitter und MyBlogLog Avatare');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare und MyBlogLog Avatare');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Smarty Tag erzeugen');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Wenn diese Option eingeschaltet ist, so wird das Avatar Bild nicht direkt in den Kommentar geschrieben, sondern es wird ein Smarty Tag {$comment.avatar} erzeugt, in dem der HTML Code des Images steht. Sie sollten diese Option nur einschalten, wenn sie wissen, dass ihr Template dieses Smarty Tag unterstützt. Ob das der Fall ist, sollten sie einfach ausprobieren.');
@@ -50,7 +50,6 @@
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
-        '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> lädt Bilder aus Twitter Profilen, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog Avatare</a></b> werden von einem zentralen Server geladen und ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');

--- a/plugins/serendipity_event_gravatar/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_de.inc.php
@@ -49,9 +49,9 @@
 @define('PLUGIN_EVENT_GRAVATAR_AUTOR_ALT_DESC',     'Normaler Weise wird der Autorenname im TITLE Attribut des Avatar Bildes angegeben, das ALT Attribut wird mit einem * gefüllt, um das Seitenlayout nicht zu zerstören, wenn der Browser das Bild nicht laden kann. Allerdings wird blinden Lesern das ALT Attribut vorgelesen. Falls Sie diese Leser unterstützen wollen, sollten Sie diese Option einschalten.');
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
-        '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
-        '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
-        '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');
+        '<b>Favatare</b> sind die Favicons auf der Homepage, die der Kommentator angegeben hat, ' .
+        '<b><a href="http://pavatar.github.io/pavatar/" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
+        '<b><a href="https://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="https://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ACHTUNG!</font> Dieses Plugin muss vor allen Plugins ausgeführt werden, die Links verändern (wie z.B. das Exit Tracking Plugin)!<br/>' .
         '<font color="red">Ansonsten werden Pavatare und Favatare nicht funktionieren!</font>');
 

--- a/plugins/serendipity_event_gravatar/lang_de.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_de.inc.php
@@ -8,7 +8,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare, Twitter, Identica und MyBlogLog Avatare');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Avatare bei Kommentaren anzeigen. Unterstützt werden Gravatare, Pavatare, Favatare, Twitter und MyBlogLog Avatare');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Smarty Tag erzeugen');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Wenn diese Option eingeschaltet ist, so wird das Avatar Bild nicht direkt in den Kommentar geschrieben, sondern es wird ein Smarty Tag {$comment.avatar} erzeugt, in dem der HTML Code des Images steht. Sie sollten diese Option nur einschalten, wenn sie wissen, dass ihr Template dieses Smarty Tag unterstützt. Ob das der Fall ist, sollten sie einfach ausprobieren.');
@@ -51,7 +51,6 @@
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatare</a></b> werden von einem zentralem Server anhand der EMail Information des Kommentators abgeholt, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatare</a></b> sind die favicons auf der Homepage, die der Kommentator angegeben hat, ' .
         '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> lädt Bilder aus Twitter Profilen, ' .
-        '<b><a href="http://identi.ca" target="_blank">Identica</a></b> lädt Bilder aus Identica Profilen, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatare</a></b> zeigen auf ein Bild, das der Besucher auf seiner Homepage hat, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog Avatare</a></b> werden von einem zentralen Server geladen und ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> und <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare sind lokal erstellte und für jeden Schreiber einzigartige Bilder.');

--- a/plugins/serendipity_event_gravatar/lang_en.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_en.inc.php
@@ -7,7 +7,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Show avatars inside comments. Gravatars, Pavatars, Favatars, Twitter and MyBlogLog avatars are supported.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Show avatars inside comments. Gravatars, Pavatars, Favatars and MyBlogLog avatars are supported.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Produce smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'If this option is switched on, the avatar images are not written directly into the comment output but a smarty tag {$comment.avatar} is produced. Only templates, that support this smarty tag, will display the avatar, if this option is set to true. The best way is to try it, if your template supports this smarty tag.');
@@ -51,7 +51,6 @@
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatars</a></b> are central-served avatar images by email, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatars</a></b> are favicons of the writer\'s site, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatars</a></b> are images at the writer\'s site, ' .
-        '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> loads twitter profile images, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatars</a></b> are central-served avatar images again and ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> and <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare are localy created monster images unique for each writer.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">CAUTION!</font> This plugin has to be executed before any plugin changing links (like i.e. the exit tracking plugin)! ' .

--- a/plugins/serendipity_event_gravatar/lang_en.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_en.inc.php
@@ -7,7 +7,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Show avatars inside comments. Gravatars, Pavatars, Favatars and MyBlogLog avatars are supported.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Show avatars inside comments. Gravatars and fallbacks like Favatars are supported.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Produce smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'If this option is switched on, the avatar images are not written directly into the comment output but a smarty tag {$comment.avatar} is produced. Only templates, that support this smarty tag, will display the avatar, if this option is set to true. The best way is to try it, if your template supports this smarty tag.');
@@ -51,10 +51,9 @@
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatars</a></b> are central-served avatar images by email, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatars</a></b> are favicons of the writer\'s site, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatars</a></b> are images at the writer\'s site, ' .
-        '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatars</a></b> are central-served avatar images again and ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> and <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare are localy created monster images unique for each writer.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">CAUTION!</font> This plugin has to be executed before any plugin changing links (like i.e. the exit tracking plugin)! ' .
-        '<font color="red">Else Pavatars, Favatars and MayBlogLog avatars won\'t work!</font>');
+        '<font color="red">Else Pavatars and Favatars avatars won\'t work!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Gravatar fallback');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar implements some fallback methods in case, no Gravatar is known for the user. It implements also Moster ID, Identicon and Wavatar. If you choose one of these, no further method after Gravatar is evaluated, if the user entered an email.');

--- a/plugins/serendipity_event_gravatar/lang_en.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_en.inc.php
@@ -49,9 +49,9 @@
 @define('PLUGIN_EVENT_GRAVATAR_AUTOR_ALT_DESC',     'Normaly the authors name is displayed in the TITLE attribute of the avatar image, the ALT attribute is filled with an *. This prevents destroying the layout, when the browser is not able to load the image. But for blind people the ALT attribute is read, so if you want to support them, switch this option on.');
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatars</a></b> are central-served avatar images by email, ' .
-        '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatars</a></b> are favicons of the writer\'s site, ' .
-        '<b><a href="http://www.pavatar.com" target="_blank">Pavatars</a></b> are images at the writer\'s site, ' .
-        '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> and <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare are localy created monster images unique for each writer.');
+        '<b>Favatars</b> are favicons of the writer\'s site, ' .
+        '<b><a href="http://pavatar.github.io/pavatar/" target="_blank">Pavatars</a></b> are images at the writer\'s site, ' .
+        '<b><a href="https://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> and <b><a href="https://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare are localy created monster images unique for each writer.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">CAUTION!</font> This plugin has to be executed before any plugin changing links (like i.e. the exit tracking plugin)! ' .
         '<font color="red">Else Pavatars and Favatars avatars won\'t work!</font>');
 

--- a/plugins/serendipity_event_gravatar/lang_en.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_en.inc.php
@@ -7,7 +7,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Show avatars inside comments. Gravatars, Pavatars, Favatars, Twitter, Identica and MyBlogLog avatars are supported.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Show avatars inside comments. Gravatars, Pavatars, Favatars, Twitter and MyBlogLog avatars are supported.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Produce smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'If this option is switched on, the avatar images are not written directly into the comment output but a smarty tag {$comment.avatar} is produced. Only templates, that support this smarty tag, will display the avatar, if this option is set to true. The best way is to try it, if your template supports this smarty tag.');
@@ -52,7 +52,6 @@
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatars</a></b> are favicons of the writer\'s site, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatars</a></b> are images at the writer\'s site, ' .
         '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> loads twitter profile images, ' .
-        '<b><a href="http://identi.ca" target="_blank">Identica</a></b> loads identi.ca profile images, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatars</a></b> are central-served avatar images again and ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> and <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> Avatare are localy created monster images unique for each writer.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">CAUTION!</font> This plugin has to be executed before any plugin changing links (like i.e. the exit tracking plugin)! ' .

--- a/plugins/serendipity_event_gravatar/lang_pl.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_pl.inc.php
@@ -7,7 +7,7 @@
  */
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Avatar Plugin');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Pokazuje avatary w komentarzach. Gravatars, Pavatars, Favatars und MyBlogLog avatars are supported.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Pokazuje avatary w komentarzach.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Produce smarty tag');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'If this option is switched on, the avatar images are not written directly into the comment output but a smarty tag {$comment.avatar} is produced. Only templates, that support this smarty tag, will display the avatar, if this option is set to true. The best way is to try it, if your template supports this smarty tag.');
@@ -58,8 +58,7 @@
 
 @define('PLUGIN_EVENT_GRAVATAR_LONG_DESCRIPTION',   '<b><a href="http://www.gravatar.com" target="_blank">Gravatars</a></b> are central-served avatar images by email, ' .
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatars</a></b> are favicons of the writer\'s site, <b><a href="http://www.pavatar.com" target="_blank">Pavatars</a></b> ' .
-        'are images at the writer\'s site, <b><a href="http://www.mybloglog.com" target="_blank">MyBlogLog avatars</a></b> are central-served avatar images again and ' .
         '<b><a href="://www.splitbrain.org/go/monsterid" target="_blank">Monster ID avatars</a></b> are localy created monster images unique for each writer.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">CAUTION!</font> This plugin has to be executed before any plugin changing links (like i.e. the exit tracking plugin)! ' .
-        '<font color="red">Else Pavatars, Favatars and MayBlogLog avatars won\'t work!</font>');
+        '<font color="red">Else Pavatars and Favatars won\'t work!</font>');
 

--- a/plugins/serendipity_event_gravatar/lang_ru.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_ru.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Плагин аватаров');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar, Twitter, Identica и MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar, Twitter и MyBlogLog.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Создать тег Smarty');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Если эта опция включена, изображения аватара не записываются непосредственно в вывод комментария, но создаётся тег smarty {$comment.avatar}. Только шаблоны, поддерживающие этот тег Smarty, будут отображать аватар, если для этой опции установлено значение "Да". Лучший способ - попробовать это, если Ваш шаблон поддерживает этот тег Smarty.');
@@ -46,7 +46,6 @@
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatar</a></b> являются иконками сайта (favicon) писателя, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatar</a></b> являются изображениями на сайте автора, ' .
         '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> загружает изображения профиля в Twitter, ' .
-        '<b><a href="http://identi.ca" target="_blank">Identica</a></b> загружает изображения профиля identi.ca, ' .
         '<b><a href="http://www.mybloglog.com" target="_blank">Аватары MyBlogLog</a></b> снова являются централизованными изображениями аватаров и ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> и <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> являются локально созданными изображениями монстров, уникальными для каждого автора.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ОСТОРОЖНО!</font> Этот плагин должен быть запущен перед любым плагином, изменяющим ссылки (например, плагин отслеживания выхода)! ' .

--- a/plugins/serendipity_event_gravatar/lang_ru.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_ru.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Плагин аватаров');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar, Twitter и MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar и MyBlogLog.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Создать тег Smarty');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Если эта опция включена, изображения аватара не записываются непосредственно в вывод комментария, но создаётся тег smarty {$comment.avatar}. Только шаблоны, поддерживающие этот тег Smarty, будут отображать аватар, если для этой опции установлено значение "Да". Лучший способ - попробовать это, если Ваш шаблон поддерживает этот тег Smarty.');

--- a/plugins/serendipity_event_gravatar/lang_ru.inc.php
+++ b/plugins/serendipity_event_gravatar/lang_ru.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 @define('PLUGIN_EVENT_GRAVATAR_NAME',               'Плагин аватаров');
-@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar, Favatar и MyBlogLog.');
+@define('PLUGIN_EVENT_GRAVATAR_DESC',               'Показ аватаров внутри комментариев. Поддерживаются Gravatar, Pavatar и Favatar.');
 
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY',         'Создать тег Smarty');
 @define('PLUGIN_EVENT_GRAVATAR_USE_SMARTY_DESC',    'Если эта опция включена, изображения аватара не записываются непосредственно в вывод комментария, но создаётся тег smarty {$comment.avatar}. Только шаблоны, поддерживающие этот тег Smarty, будут отображать аватар, если для этой опции установлено значение "Да". Лучший способ - попробовать это, если Ваш шаблон поддерживает этот тег Smarty.');
@@ -46,10 +46,9 @@
         '<b><a href="http://www.peej.co.uk/projects/favatars.html" target="_blank">Favatar</a></b> являются иконками сайта (favicon) писателя, ' .
         '<b><a href="http://www.pavatar.com" target="_blank">Pavatar</a></b> являются изображениями на сайте автора, ' .
         '<b><a href="http://twitter.com" target="_blank">Twitter</a></b> загружает изображения профиля в Twitter, ' .
-        '<b><a href="http://www.mybloglog.com" target="_blank">Аватары MyBlogLog</a></b> снова являются централизованными изображениями аватаров и ' .
         '<b><a href="http://www.splitbrain.org/go/monsterid" target="_blank">Monster ID</a></b>, <b><a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/" target="_blank">Identicon</a></b> и <b><a href="http://www.shamusyoung.com/twentysidedtale/?p=1462" target="_blank">Wavatar</a></b> являются локально созданными изображениями монстров, уникальными для каждого автора.');
 @define('PLUGIN_EVENT_GRAVATAR_EXTLING_WARNING',    '<font color="red">ОСТОРОЖНО!</font> Этот плагин должен быть запущен перед любым плагином, изменяющим ссылки (например, плагин отслеживания выхода)! ' .
-        '<font color="red">В противном случае аватары Pavatar, Favatar и MayBlogLog не будут работать!</font>');
+        '<font color="red">В противном случае аватары Pavatar и Favatar не будут работать!</font>');
 
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK',           'Запасной вариант Gravatar');
 @define('PLUGIN_EVENT_GRAVATAR_FALLBACK_DESC',      'Gravatar реализует некоторые запасные методы на случай, если пользователю не известен Gravatar. Он также реализует Moster ID, Identificate и Avatar. Если Вы выберете один из них, никакой другой метод после Gravatar не будет обработан, если пользователь ввёл адрес электронной почты.');

--- a/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
+++ b/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
@@ -942,9 +942,12 @@ class serendipity_event_gravatar extends serendipity_event
         $size = $default['size'];
 
         // Save monster image
-        @mkdir($this->getCacheDirectory());
+        if (! file_exists($this->getCacheDirectory())) {
+            @mkdir($this->getCacheDirectory());
+        }
         $cache_file = $this->getCacheFilePath($eventData);
         $this->log("Caching monster avatar: " . $cache_file);
+        
         if (build_monster($cache_file, $seed, $size)) {
             $this->log("Success caching monster.");
             $this->avatarConfiguration['mime-type'] = "image/png";
@@ -973,10 +976,13 @@ class serendipity_event_gravatar extends serendipity_event
         $size = $default['size'];
 
         // Save monster image
-        @mkdir($this->getCacheDirectory());
+        if (! file_exists($this->getCacheDirectory())) {
+            @mkdir($this->getCacheDirectory());
+        }
         $cache_file = $this->getCacheFilePath($eventData);
         $this->log("Caching wavatar avatar: " . $cache_file);
-        if (wavatar_build($cache_file, $seed, $size)) {
+        wavatar_build($seed, $cache_file, $size);
+        if (file_exists($cache_file)) {
             $this->log("Success caching wavatar.");
             $this->avatarConfiguration['mime-type'] = "image/png";
             $this->show($cache_file);
@@ -1006,7 +1012,9 @@ class serendipity_event_gravatar extends serendipity_event
         $size = $default['size'];
 
         // Save monster image
-        @mkdir($this->getCacheDirectory());
+        if (! file_exists($this->getCacheDirectory())) {
+            @mkdir($this->getCacheDirectory());
+        }
         $cache_file = $this->getCacheFilePath($eventData);
         $this->log("Caching Identicon/Ycon avatar: " . $cache_file);
         if (build_ycon($cache_file,$seed,$size)) {

--- a/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
+++ b/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
@@ -20,8 +20,6 @@ class serendipity_event_gravatar extends serendipity_event
 {
     var $title = PLUGIN_EVENT_GRAVATAR_NAME;
 
-    // Holds MD5 code for the MyBlogLog dummy icon.
-    var $mybloglog_dummy_md5        = null;
     var $cache_dir                  = null;
     var $defaultImageConfiguration  = null;
     var $defaultImageConfigurationdefault = null;
@@ -403,9 +401,6 @@ class serendipity_event_gravatar extends serendipity_event
                                 break;
                             case 'pavatar':
                                 $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.pavatar.com">Pavatar</a>';
-                                break;
-                            case 'mybloglog':
-                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.mybloglog.com">MyBlogLog</a>';
                                 break;
                             case 'monsterid':
                                 $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.splitbrain.org/go/monsterid">Monster ID</a>';

--- a/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
+++ b/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
@@ -394,16 +394,16 @@ class serendipity_event_gravatar extends serendipity_event
                         $act_method = $this->get_config("method_".$methodnr);
                         switch ($act_method){
                             case 'gravatar':
-                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.gravatar.com">Gravatar</a>';
+                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="https://www.gravatar.com">Gravatar</a>';
                                 break;
                             case 'favatar':
-                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.peej.co.uk/projects/favatars.html">Favatar</a>';
+                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . 'Favatar (Favicons)';
                                 break;
                             case 'pavatar':
-                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.pavatar.com">Pavatar</a>';
+                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://pavatar.github.io/pavatar/">Pavatar</a>';
                                 break;
                             case 'monsterid':
-                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://www.splitbrain.org/go/monsterid">Monster ID</a>';
+                                $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="https://www.splitbrain.org/go/monsterid">Monster ID</a>';
                                 break;
                             case 'identicon':
                                 $supported_methods .= (empty($supported_methods) ? '' : ', ') . '<a href="http://scott.sherrillmix.com/blog/blogger/wp_identicon/">Identicon/Ycon</a>';

--- a/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
+++ b/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
@@ -42,6 +42,7 @@ class serendipity_event_gravatar extends serendipity_event
         ));
         $propbag->add('version',       PLUGIN_EVENT_GRAVATAR_VERSION);
         $propbag->add('groups',        array('IMAGES'));
+        $propbag->add('copyright',     'GPLv2 (or later)');
         $propbag->add('event_hooks',   array(
             'frontend_display' => true,
             'frontend_comment' => true,

--- a/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
+++ b/plugins/serendipity_event_gravatar/serendipity_event_gravatar.php
@@ -8,7 +8,7 @@ if (IN_serendipity !== true) {
 @serendipity_plugin_api::load_language(dirname(__FILE__));
 
 // Actual version of this plugin
-@define('PLUGIN_EVENT_GRAVATAR_VERSION', '1.63.1');
+@define('PLUGIN_EVENT_GRAVATAR_VERSION', '2.0');
 
 // Defines the maximum available method  slots in the configuration.
 @define('PLUGIN_EVENT_GRAVATAR_METHOD_MAX', 6);

--- a/plugins/serendipity_event_gravatar/wavatars/wavatars.php
+++ b/plugins/serendipity_event_gravatar/wavatars/wavatars.php
@@ -4,17 +4,219 @@ Plugin Name: Wavatars
 Plugin URI: http://www.shamusyoung.com/twentysidedtale/?p=1462
 Description: A plugin which generates random avatars for comments.
 Author: Shamus Young
-Version: 1.0.0
+Version: 1.1.3
 Author URI: http://www.shamusyoung.com/twentysidedtale/
 */
 
-define("WAVATAR_SIZE",          "80");
-define("WAVATAR_BACKGROUNDS",   "4");
-define("WAVATAR_FACES",         "11");
-define("WAVATAR_BROWS",         "8");
-define("WAVATAR_EYES",          "13");
-define("WAVATAR_PUPILS",        "11");
-define("WAVATAR_MOUTHS",        "19");
+define("AVATAR_SIZE",           '80');
+define("WAVATAR_BACKGROUNDS",   '4');
+define("WAVATAR_FACES",         '11');
+define("WAVATAR_BROWS",         '8');
+define("WAVATAR_EYES",          '13');
+define("WAVATAR_PUPILS",        '11');
+define("WAVATAR_MOUTHS",        '19');
+define("WAVATAR_BLANK",         'wp-content/cache/wavatars/blank.png');
+
+/*-----------------------------------------------------------------------------
+This is used to help build the options page.
+-----------------------------------------------------------------------------*/
+
+function wavatar_row ($title, $field, $help='', $checkbox=false)
+{
+
+    echo '<tr valign="top"><th scope="row">';
+    _e("$title");
+    echo '</th><td>';
+    if ($checkbox) {
+        echo "<input name='$field' type='checkbox' id='$field' value='1' ";
+        checked('1', get_option($field));
+        echo '/>';
+    } else { //not a checkbox
+        echo "<input name='$field' type='text' id='$field' value='";
+        form_option("$field");
+        echo "'";
+        echo ' size="40" /><br/>';
+    }
+    echo "$help";
+    echo '</td></tr>';
+    echo "\n\n";
+
+}
+
+/*-----------------------------------------------------------------------------
+ This builds the options page where you can administrate the plugin rather
+ than mucking about here in the source code.  Which you seem to be doing anyway.
+-----------------------------------------------------------------------------*/
+
+function wavatar_options ()
+{
+
+    $hidden_field_name = 'wavatar_update';
+    echo '<div class="wrap">';
+    echo '<h2>Wavatar Options</h2>';
+    echo '<h3>Configuration</h3>';
+    $variations = WAVATAR_BACKGROUNDS * WAVATAR_FACES * WAVATAR_BROWS * WAVATAR_EYES * WAVATAR_PUPILS * WAVATAR_MOUTHS;
+    // See if the user has chosen to purge the cache
+    if ($_POST['wavatar_clear_cache'] == 'Y') {
+        $localdir = "../wp-content/cache/wavatars";
+        echo '<div class="updated"><p><strong>';
+        $dir = opendir ($localdir);
+        if ($dir) {
+            $file_count = 0;
+            $delete_count = 0;
+            while (($file = readdir ($dir)) !== false) {
+                //only delete .png files.
+                if (!strstr ($file, '.png'))
+                    continue;
+                $file_count++;
+                if (unlink ($localdir . '/' . $file))
+                    $delete_count++;
+            }
+            if ($file_count == 0)
+                echo 'The cache is already empty.';
+            else
+                echo $delete_count . ' icons deleted.';
+        } else
+            echo 'Cannot open directory for reading.';
+        echo '</strong></p></div>';
+    }
+
+    // See if the user has posted us some information
+    // If they did, this hidden field will be set to 'Y'
+    if( $_POST[ $hidden_field_name ] == 'Y' ) {
+        // Save the posted value in the database
+        update_option ('wavatar_auto', $_POST['wavatar_auto']);
+        update_option ('wavatar_noplug', $_POST['wavatar_noplug']);
+        update_option ('wavatar_size', intval ($_POST['wavatar_size']));
+        update_option ('wavatar_border', intval ($_POST['wavatar_border']));
+        update_option ('wavatar_suffix', $_POST['wavatar_suffix']);
+        update_option ('wavatar_prefix', $_POST['wavatar_prefix']);
+        update_option ('wavatar_gravatars', $_POST['wavatar_gravatars']);
+        update_option ('wavatar_rating', $_POST['wavatar_rating']);
+        update_option ('wavatar_email_blank', $_POST['wavatar_email_blank']);
+        // Put an options updated message on the screen
+        ?>
+        <div class="updated"><p><strong><?php _e('Options saved.', 'mt_trans_domain' ); ?></strong></p></div>
+        <?php
+    }
+    $size = get_option ("wavatar_size");
+    if (empty ($size))
+        add_option ("wavatar_size", AVATAR_SIZE);
+
+    //give a warning if the image functions are not available
+    if (!function_exists (imagecreatetruecolor)) {
+        echo '<div class="error"><p><strong>NOTE: It appears as though the GD2 Library for PHP  is not available to Wordpress. This plugin will still be able to display Gravatars ';
+        if (!get_option ('wavatar_gravatars'))
+            echo '(if you enable them below) ';
+        echo 'but it can\'t build wavatars.';
+        echo '</strong></p></div>';
+    }
+
+    ?>
+<table class="optiontable">
+<form name="form1" method="post" action="<?php echo str_replace( '%7E', '~', $_SERVER['REQUEST_URI']); ?>">
+<input type="hidden" name="<?php echo $hidden_field_name; ?>" value="Y">
+<?php
+    wavatar_row ('Automatic Placement', 'wavatar_auto', "This will cause wordpress to always display the image directly before the user's name. If you uncheck this, you will have to add avatars to your theme manually by calling <code>wavatar_show(\$comment-&gt;comment_author_email)</code> in your theme comment loop.", true);
+    wavatar_row ('Size', 'wavatar_size', 'The size of the icons.  Note that you should clear the cache if you change this.');
+    wavatar_row ('Prefix', 'wavatar_prefix', 'HTML to come BEFORE the image.  This can be useful for encasing the icon within &lt;div&gt; tags, for example.');
+    wavatar_row ('Suffix', 'wavatar_suffix', 'HTML to come AFTER the image.  This is good for closing any tags you may have opened with the Prefix.');
+    wavatar_row ('Border', 'wavatar_border', 'The size of the border around the icons.');
+    wavatar_row ('Gravatar Support', 'wavatar_gravatars', "Use Gravatars if available, and only use wavatars if the user doesn't have a Gravatar.", true);
+    wavatar_row ('Gravatar Rating', 'wavatar_rating', "The max rating of the requested Gravatars.  This value should be G, PG, R, or X.");
+?>
+<tr valign="top"><th scope="row">When user leaves email field blank:</th><td>
+<input name="wavatar_email_blank" type="radio" value="" class="tog"       <?php checked(get_option ('wavatar_email_blank'), ''); ?> /> Generate wavatar anyway<br>
+<input name="wavatar_email_blank" type="radio" value="omit" class="tog"   <?php checked(get_option ('wavatar_email_blank'), 'omit'); ?> /> Show no image<br>
+<input name="wavatar_email_blank" type="radio" value="blank" class="tog"  <?php checked(get_option ('wavatar_email_blank'), 'blank'); ?> /> Display a blank Image<br>
+</td></tr>
+<?php
+    echo '</table>';
+    wavatar_row ('', 'wavatar_noplug', "Suppress the link back to the Wavatar homepage in the site footer.", true);
+
+?>
+
+</table>
+
+<p class="submit">
+<input type="submit" name="Submit" value="<?php _e('Update Options', 'mt_trans_domain' ) ?>" />
+</p>
+</table>
+</form>
+<hr />
+<h3>Cache</h3>
+
+<form name="form1" method="post" action="<?php echo str_replace( '%7E', '~', $_SERVER['REQUEST_URI']); ?>">
+<p>If you change the image size or alter the source images, you will need to clear the cached images for the changes
+to take effect on existing icons.  You can also do this in order to free up disk space.  You can do this manually
+by deleting all of the files in the <tt>/wp-content/cache/wavatars</tt> directory, or you can press the button below.
+
+<?php
+    $localdir = "../wp-content/cache/wavatars";
+    $dir = opendir ($localdir);
+    if ($dir) {
+        $file_count = 0;
+        $delete_count = 0;
+        while (($file = readdir ($dir)) !== false) {
+            //only delete .png files.
+            if (!strstr ($file, '.png'))
+                continue;
+            $file_count++;
+        }
+        if ($file_count == 0)
+            echo 'The cache is currently empty.';
+        else
+            echo "There are $file_count icons currently in the cache.";
+    } else
+        echo 'Cannot open directory for reading.';
+?>
+
+<p class="submit"><input type="hidden" name="wavatar_clear_cache" value="Y">
+<input type="submit" name="Submit" value="Empty Cache" />
+</form>
+<hr />
+<center><i>Wavatars can generate <?php echo number_format ($variations); ?> different shapes in
+<?php echo number_format (240 * 240); ?> different color combinations for a total of
+<?php echo number_format ($variations * 240 * 240); ?> unique Wavatars.</center></i>
+</div>
+<?php
+
+}
+
+/*-----------------------------------------------------------------------------
+Add wavatar admin pages to WP interface.
+-----------------------------------------------------------------------------*/
+
+function wavatar_add_pages ()
+{
+
+    if (function_exists('add_theme_page'))
+        add_options_page('Wavatar Options', 'Wavatars', 8, 'wavataroptions', 'wavatar_options');
+}
+
+/*-----------------------------------------------------------------------------
+This puts a link back to me in the page footer.  You can disable it in the
+options or here in the source, but you'll hurt my feelings. :)
+-----------------------------------------------------------------------------*/
+
+function wavatar_plug ()
+{
+    
+    if (get_option ('wavatar_noplug'))
+        return;
+    echo 'This site employs the <a href="http://www.shamusyoung.com/twentysidedtale/?p=1462">Wavatars plugin</a> by Shamus Young.';
+
+}
+
+
+/*-----------------------------------------------------------------------------
+Clamp a value between 0 and 255
+-----------------------------------------------------------------------------*/
+
+function wavatar_clamp ($v)
+{
+    return $v < 0 ? 0 : ($v > 255 ? 255 : $v);
+}
 
 /*-----------------------------------------------------------------------------
 Handy function for converting hus/sat/lum color values to RGB, which makes it
@@ -24,9 +226,8 @@ very easy to generate random-yet-still-vibrant colors.
 function wavatar_hsl ($h, $s, $l) 
 {
 
-    if ($h>240 || $h<0) return array(0,0,0);
-    if ($s>240 || $s<0) return array(0,0,0);
-    if ($l>240 || $l<0) return array(0,0,0);     
+    if ($h>240 || $h<0 || $s>240 || $s<0 || $l>240 || $l<0)
+        return array(0,0,0);
     if ($h<=40) {
         $R=255;
         $G=(int)($h/40*256);
@@ -64,13 +265,7 @@ function wavatar_hsl ($h, $s, $l)
         $G=$l*((256-$G)/120)+2*$G-256;
         $B=$l*((256-$B)/120)+2*$B-256;
     }
-    if ($R<0) $R=0;
-    if ($R>255) $R=255;
-    if ($G<0) $G=0;
-    if ($G>255) $G=255;
-    if ($B<0) $B=0;
-    if ($B>255) $B=255;
-    return array((int)$R,(int)$G,(int)$B);
+    return array((int)wavatar_clamp ($R),(int)wavatar_clamp($G),(int)wavatar_clamp($B));
 
 }
 
@@ -83,12 +278,10 @@ function wavatar_apply_image ($base, $part)
 {
 
     $file = dirname(__FILE__).'/parts/' . $part . '.png';
-    //echo $file . "<br>";
     $im = @imagecreatefrompng($file);
     if(!$im)
         return;
-    imageSaveAlpha($im, true);
-    imagecopy($base,$im, 0, 0, 0, 0, WAVATAR_SIZE, WAVATAR_SIZE);
+    imagecopy($base,$im, 0, 0, 0, 0, AVATAR_SIZE, AVATAR_SIZE);
     imagedestroy($im);
 
 }
@@ -97,11 +290,11 @@ function wavatar_apply_image ($base, $part)
 Builds the avatar.
 -----------------------------------------------------------------------------*/
 
-function wavatar_build ($filename, $seed, $size)
+function wavatar_build ($seed, $filename, $size)
 {
-    if (!function_exists (imagecreatetruecolor)) {
-        return false;
-    }
+
+    //look at the seed (an md5 hash) and use pairs of digits to determine our
+    //"random" parts and colors.
     $face =         1 + (hexdec (substr ($seed,  1, 2)) % (WAVATAR_FACES));
     $bg_color =         (hexdec (substr ($seed,  3, 2)) % 240);
     $fade =         1 + (hexdec (substr ($seed,  5, 2)) % (WAVATAR_BACKGROUNDS));
@@ -111,27 +304,26 @@ function wavatar_build ($filename, $seed, $size)
     $pupil =        1 + (hexdec (substr ($seed, 13, 2)) % (WAVATAR_PUPILS));
     $mouth =        1 + (hexdec (substr ($seed, 15, 2)) % (WAVATAR_MOUTHS));
     // create backgound
-    $avatar = imagecreatetruecolor (WAVATAR_SIZE, WAVATAR_SIZE);
+    $avatar = imagecreatetruecolor (AVATAR_SIZE, AVATAR_SIZE);
     //Pick a random color for the background
     $c = wavatar_hsl ($bg_color, 240, 50);
     $bg = imagecolorallocate ($avatar, $c[0], $c[1], $c[2]);
-    imagefill($avatar,0,0,$bg);
+    imagefill($avatar, 1, 1, $bg);
     $c = wavatar_hsl ($wav_color, 240, 170);
     $bg = imagecolorallocate ($avatar, $c[0], $c[1], $c[2]);
     //Now add the various layers onto the image
     wavatar_apply_image ($avatar, "fade$fade");
     wavatar_apply_image ($avatar, "mask$face");
-    imagefill($avatar, WAVATAR_SIZE / 2,WAVATAR_SIZE / 2,$bg);
+    imagefill($avatar, (int)(AVATAR_SIZE / 2),(int)(AVATAR_SIZE / 2),$bg);
     wavatar_apply_image ($avatar, "shine$face");
     wavatar_apply_image ($avatar, "brow$brow");
     wavatar_apply_image ($avatar, "eyes$eyes");
     wavatar_apply_image ($avatar, "pupils$pupil");
     wavatar_apply_image ($avatar, "mouth$mouth");
     //resize if needed
-    if ($size != WAVATAR_SIZE) {
+    if ($size != AVATAR_SIZE) {
         $out = imagecreatetruecolor($size,$size);
-        imagecopyresampled ($out,$avatar, 0, 0, 0, 0, $size, $size, WAVATAR_SIZE, WAVATAR_SIZE);
-        //header ("Content-type: image/png");
+        imagecopyresampled ($out,$avatar, 0, 0, 0, 0, $size, $size, AVATAR_SIZE, AVATAR_SIZE);
         imagepng($out, $filename);
         imagedestroy($out);
         imagedestroy($avatar);
@@ -139,7 +331,111 @@ function wavatar_build ($filename, $seed, $size)
         imagepng($avatar, $filename);
         imagedestroy($avatar);
     }
-    return true;
+
+}
+
+/*-----------------------------------------------------------------------------
+Builds a blank 1x1 avatar
+-----------------------------------------------------------------------------*/
+
+function wavatar_build_blank ()
+{
+
+    if (file_exists (WAVATAR_BLANK))
+        return;
+    $avatar = imagecreatetruecolor (1, 1);
+    $bg = imagecolorallocate ($avatar, 255, 255, 255);
+    imagefill($avatar, 0, 0, $bg);
+    imagepng($avatar, WAVATAR_BLANK);
+    imagedestroy($avatar);
+    
+}
+
+/*-----------------------------------------------------------------------------
+This makes sure that the image is present (builds it if it isn't) and then
+returns the url.
+-----------------------------------------------------------------------------*/
+
+function wavatar_get ($email, $size='')
+{
+
+    $email_blank = get_option ('wavatar_email_blank');
+    if ($email == '') {
+        if (get_option ('wavatar_email_blank') == 'omit')
+            return '';
+        if (get_option ('wavatar_email_blank') == 'blank') {
+            wavatar_build_blank ();
+            return WAVATAR_BLANK;
+        }
+    }
+    $md5 = md5($email);
+    $seed = substr ($md5, 0, 17);
+    $rating = get_option ('wavatar_rating');
+    if ($size == '')
+        $size = get_option ("wavatar_size");
+    if ($size == 0)
+        $size = AVATAR_SIZE;
+    //make sure the image functions are available before trying to make wavatars
+    if (function_exists (imagecreatetruecolor)) {
+        //make sure the cache directory is available
+        $dir = "wp-content/cache/wavatars";
++       $localdir = ABSPATH . $dir;
+        if (!file_exists ($localdir) && !wp_mkdir_p ($localdir))
+            return;
+        $dest = $localdir . "/$seed.png";
+        $url = get_bloginfo ('wpurl') . "/$dir/$seed.png";
+        if (!file_exists ($dest))
+            wavatar_build ($seed, $dest, $size);
+    } else //image functions not available
+        $url == '';
+    if (get_option ('wavatar_gravatars')) {
+        $default = $url;
+        $url = "http://www.gravatar.com/avatar.php?gravatar_id=$md5.jpg&amp;";
+        if (strlen ($rating))
+            $url .= "r=$rating&amp;";
+        $url .= "s=$size&amp;d=" . urlencode($default);
+    }
+    return $url;
+
+}
+
+/*-----------------------------------------------------------------------------
+This makes sure that the image is present (builds it if it isn't) and then
+displays it.
+-----------------------------------------------------------------------------*/
+
+function wavatar_show ($email, $size='')
+{
+
+    if (get_option ('wavatar_email_blank') == 'omit' && $email == '')
+        return '';
+    if ($size == '')
+        $size = get_option ("wavatar_size");
+    if ($size == 0)
+        $size = AVATAR_SIZE;
+    $email = strtolower ($email);
+    $url = wavatar_get ($email, $size);
+    echo get_option('wavatar_prefix');
+    echo "<img class='wavatar' src='$url' width='$size' height='$size' alt='Wavatar' />";
+    echo get_option('wavatar_suffix');
+
+}
+
+/*-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------*/
+
+function wavatar_comment_author ($author)
+{
+
+    global $comment;
+
+    if (is_page () || is_single ()) {
+        if (get_option ('wavatar_auto'))
+            return wavatar_show ($comment->comment_author_email) . " " . $author;
+    }
+    return $author;
+
 }
 
 ?>


### PR DESCRIPTION
A thorough update of the gravatar plugin.

Some avatar options were broken. This PR fixes the gravatar option by moving from md5 hashes to the now required sha256. It removes the other two that broke, identica and twitter. In both cases the used APIs do not exist anymore (though for identica it's possible that there are alternatives, if someone wants to maintain that integration again - I just saw no clear solution, but might have missed something).

With sha256 used for gravatar, I also changed all other plugin hashes to use sha256.

The wavatar generator had a slightly newer version, which gets used now. This fixes a PHP 8 compatibility issue. There were some additional PHP 8 fixes throughout the plugin, and that PHP version is now set as required.

Documentation and translations were outdated. This PR fixes the links that explain the various avatar options - apart from favatars, there is nothing online, so this became just text. It also removes the remaining references to MyBlogLog missed in https://github.com/s9y/Serendipity/commit/26c462acff68a6ad49ed4dca25150bab72f0df56, and the now removed services.