### PR TITLE
bugfix: pg_escape_string() in serendipity_db_escape_string() works again

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,5 +1,8 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
+   * Fix pg_escape_string on PHP 8.1 and later (thanks to HQJaTu Jari
+     Turkia)
+
    * Avoid PHP 8 warning about incurrect reference return of db_query
      function
 
@@ -39,7 +42,7 @@ Version 2.6-alpha1 ()
      integrated search box when 2k11 is used as the default theme
 
    * Fix specific search terms (like a - at the end) causing an error
-     page when using MySQL/MariaDB (thanks to  GuillaumeValadas) 
+     page when using MySQL/MariaDB (thanks to GuillaumeValadas) 
 
    * Swap order of entries in the dashboard, so that upcoming
      entries are shown first

--- a/include/db/postgres.inc.php
+++ b/include/db/postgres.inc.php
@@ -89,7 +89,9 @@ function serendipity_db_reconnect() {
  * @return  string   output string
  */
 function serendipity_db_escape_string($string) {
-    return pg_escape_string($string);
+    global $serendipity;
+
+    return pg_escape_string($serendipity['dbConn'], $string);
 }
 
 /**


### PR DESCRIPTION
https://github.com/s9y/Serendipity/pull/855 without the additional commits. I cherry-picked the first commit with the fix for pg_escape_string. 

I debated also picking the PHP version check, but according to the documentation that might not be necessary - the new code should work also in old versions.