### PR TITLE
Mark intl as required dependency

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,5 +1,8 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
+   * Mark the intl extension as a requirement in the installer. It is
+     needed to not have an error after the install
+
    * Fix warning about dynamic properties in core plugins, relevant for
      PHP 8.2 and later (thanks to HQJaTu Jari Turkia)
 

--- a/include/admin/installer.inc.php
+++ b/include/admin/installer.inc.php
@@ -175,7 +175,7 @@ if ( (int)($serendipity['GET']['step'] ?? null) == 0 ) {
     if ( extension_loaded('intl') ) {
         $data['installerResultDiagnose_INTL'] =  serendipity_installerResultDiagnose(S9Y_I_SUCCESS, YES);
     } else {
-        $data['installerResultDiagnose_INTL'] =  serendipity_installerResultDiagnose(S9Y_I_WARNING, NO);
+        $data['installerResultDiagnose_INTL'] =  serendipity_installerResultDiagnose(S9Y_I_ERROR, NO);
     }
 
     if ( extension_loaded('zlib') ) {


### PR DESCRIPTION
Without the extension php81_bc/strftime causes a critical error