### PR TITLE
Remove remnants of /archives as filesystem directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ plugins/additional_plugins*
 /.htaccess
 *.db
 private/*
-archives/*
 *~
 DEADJOE
 /.settings

--- a/include/admin/installer.inc.php
+++ b/include/admin/installer.inc.php
@@ -268,18 +268,6 @@ if ( (int)($serendipity['GET']['step'] ?? null) == 0 ) {
         }
     }
 
-    if ( is_writable($basedir . 'archives/') ) {
-        $data['installerResultDiagnose_ARCHIVES'] =  serendipity_installerResultDiagnose(S9Y_I_SUCCESS, WRITABLE);
-    } else {
-        if ($basewritable && !is_dir($basedir . 'archives/')) {
-            $data['installerResultDiagnose_ARCHIVES'] =  serendipity_installerResultDiagnose(S9Y_I_SUCCESS, WRITABLE);
-            #This directory will be created later in the process
-        } else {
-            $data['installerResultDiagnose_ARCHIVES'] =  serendipity_installerResultDiagnose(S9Y_I_ERROR, NOT_WRITABLE);
-            $showWritableNote = true;
-        }
-    }
-
     if ( is_writable($basedir . 'plugins/') ) {
         $data['installerResultDiagnose_PLUGINS'] =  serendipity_installerResultDiagnose(S9Y_I_SUCCESS, WRITABLE);
     } else {

--- a/include/admin/upgrader.inc.php
+++ b/include/admin/upgrader.inc.php
@@ -418,12 +418,11 @@ if (($showAbort && $serendipity['GET']['action'] == 'ignore') || $serendipity['G
         #Figure out if we're set up a little more securely
         #PATH_SMARTY_COMPILE/
         #uploads/
-        #archives/
         #.htaccess
         #serendipity_config_local.inc.php
         # For completeness we could test to make sure the directories
         # really are directories, but that's probably overkill
-        foreach (array('archives/', PATH_SMARTY_COMPILE . '/', 'uploads/', '.htaccess', 'serendipity_config_local.inc.php') as $path) {
+        foreach (array(PATH_SMARTY_COMPILE . '/', 'uploads/', '.htaccess', 'serendipity_config_local.inc.php') as $path) {
             if (!is_writeable($basedir . $path)) {
                 $data['upgraderResultDiagnose2'][] = serendipity_upgraderResultDiagnose(S9Y_U_ERROR, NOT_WRITABLE);
                 $showWritableNote = true;

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -826,15 +826,6 @@ function serendipity_rebuildCategoryTree($parent = 0, $left = 0) {
  */
 function &serendipity_searchEntries($term, $limit = '', $searchresults = '') {
     global $serendipity;
-    static $log_queries = false;
-
-    if ($log_queries) {
-        $fp = fopen($serendipity['serendipityPath'] . '/archives/queries.csv', 'a');
-        fwrite($fp, date('Y-m-d H:i') . ';'
-                    . $_SERVER['REMOTE_ADDR'] . ';'
-                    . $term . "\n");
-        fclose($fp);
-    }
 
     $orig_limit = $limit;
     if ($limit == '') {

--- a/templates/2k11/admin/installer.inc.tpl
+++ b/templates/2k11/admin/installer.inc.tpl
@@ -199,10 +199,6 @@
                             <td>{$installerResultDiagnose_COMPILE}</td>
                         </tr>
                         <tr>
-                            <td><h5>{$basedir}archives/</h5></td>
-                            <td>{$installerResultDiagnose_ARCHIVES}</td>
-                        </tr>
-                        <tr>
                             <td><h5>{$basedir}plugins</h5></td>
                             <td>{$installerResultDiagnose_PLUGINS}</td>
                         </tr>


### PR DESCRIPTION
As s9y works currently, the **/archives**directory is not needed. `/archives` is used as a path in the URL, but the entry is completely created dynamically from the database. There was old code to store entries as files under **/archives/**, but that code was either never or never in the last 20 years in use. But the installer still checked that **/archives** exists and is writeable. 

This PR removes the check and the few other references. It will not removes the directory on existing installations, after all user might have stored files there.