### PR TITLE
Make entry_id an unsigned integer

### DIFF
--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -1718,7 +1718,7 @@ class serendipity_event_spamblock extends serendipity_event
             default:
                 $q = sprintf("INSERT INTO {$serendipity['dbPrefix']}spamblocklog
                                           (timestamp, type, reason, entry_id, author, email, url,  useragent, ip,   referer, body)
-                                   VALUES (%d,        '%s',  '%s',  '%s',     '%s',   '%s',  '%s', '%s',      '%s', '%s',    '%s')",
+                                   VALUES (%d,        '%s',  '%s',  '%u',     '%s',   '%s',  '%s', '%s',      '%s', '%s',    '%s')",
 
                            serendipity_serverOffsetHour(),
                            serendipity_db_escape_string($switch),


### PR DESCRIPTION
Fixes: PHP Fatal error:  Uncaught mysqli_sql_exception:
 Incorrect integer value: '' for column `serendipity`.`serendipity_spamblocklog`.`entry_id`

Issue with php 8.4
