### PR TITLE
Fix comments archive pagination

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.6-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Fix pagination on /comments archive, so that not only the first
+     page shows comments
+
    * Changes to the internal cache, the one that can be configured in
      the general settings. It will now use a custom implementation that
      either caches to the file system or to APCu, if available. The

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -435,12 +435,13 @@ function serendipity_printComments($comments, $parentid = 0, $depth = 0, $trace 
 }
 
 /**
- * Fetches and prints a listing of comments by author
+ * Fetches and prints a listing of comments by author, or a page of all comments if
+ * serendipity['GET']['viewCommentAuthor'] is empty
  */
 function serendipity_printCommentsByAuthor() {
     global $serendipity;
 
-    $type = serendipity_db_escape_string($serendipity['GET']['commentMode']);
+    $type = serendipity_db_escape_string($serendipity['GET']['commentMode'] ?? '');
 
     if ($type == 'comments' || empty($type)) {
         $type = 'NORMAL';
@@ -486,14 +487,6 @@ function serendipity_printCommentsByAuthor() {
     }
 
     $serendipity['smarty']->assignByRef('comments_by_authors', $entry_comments);
-
-    if (!empty($id)) {
-        $and .= " AND co.entry_id = '" . (int)$id ."'";
-    }
-
-    if (!$showAll) {
-        $and .= ' AND co.status = \'approved\'';
-    }
 
     $fc = "SELECT count(co.id) AS counter
                                   FROM {$serendipity['dbPrefix']}comments AS co

--- a/include/functions_routing.inc.php
+++ b/include/functions_routing.inc.php
@@ -83,6 +83,18 @@ function serveComments() {
             continue;
         }
 
+        if (strlen($v) > 0) {
+            if ($v[0] == 'P') { /* Page */
+                $page = substr($v, 1);
+                if (is_numeric($page)) {
+                    $serendipity['GET']['page'] = $page;
+                    unset($_args[$k]);
+                    unset($serendipity['uriArguments'][$k]);
+                    continue;
+                }
+            }
+        }
+
         if (preg_match('@^(last|f|t|from|to)[\s_-]*([\d/ -]+)$@', strtolower(urldecode($v)), $m)) {
             if ($m[1] == 'last') {
                 $usetime = time() - ($m[2]*86400);
@@ -106,11 +118,11 @@ function serveComments() {
         } elseif ($v == 'trackbacks' || $v == 'comments_and_trackbacks' || $v == 'comments') {
             $serendipity['GET']['commentMode'] = $v;
         } elseif (!empty($v)) {
-            $serendipity['GET']['viewCommentAuthor'] .= urldecode($v);
+            $serendipity['GET']['viewCommentAuthor'] = ($serendipity['GET']['viewCommentAuthor'] ?? '') . urldecode($v);
         }
     }
 
-    $serendipity['head_title']    = COMMENTS_FROM . ' ' . serendipity_specialchars($serendipity['GET']['viewCommentAuthor']);
+    $serendipity['head_title']    = COMMENTS_FROM . ' ' . serendipity_specialchars($serendipity['GET']['viewCommentAuthor'] ?? '');
     if (isset($timedesc['start']) && isset($timedesc['end'])) {
         $serendipity['head_title'] .= ' (' . $timedesc['start'] . ' - ' . $timedesc['end'] . ')';
     } elseif (isset($timedesc['start'])) {

--- a/include/functions_routing.inc.php
+++ b/include/functions_routing.inc.php
@@ -29,7 +29,7 @@ function serve404() {
 }
 
 
-/* Attempt to locate hidden variables within the URI */
+/** Attempt to locate hidden variables within the URI and set the corresponding global variables */
 function locateHiddenVariables($_args) {
     global $serendipity;
     foreach ($_args AS $k => $v){
@@ -75,24 +75,13 @@ function serveComments() {
     $serendipity['view'] = 'comments';
     $uri = $_SERVER['REQUEST_URI'];
     $_args = serendipity_getUriArguments($uri, true); // Need to also match "." character
+    $_args = locateHiddenVariables($_args);
     $timedesc = array();
 
     /* Attempt to locate hidden variables within the URI */
     foreach ($_args AS $k => $v){
         if ($v == PATH_COMMENTS) {
             continue;
-        }
-
-        if (strlen($v) > 0) {
-            if ($v[0] == 'P') { /* Page */
-                $page = substr($v, 1);
-                if (is_numeric($page)) {
-                    $serendipity['GET']['page'] = $page;
-                    unset($_args[$k]);
-                    unset($serendipity['uriArguments'][$k]);
-                    continue;
-                }
-            }
         }
 
         if (preg_match('@^(last|f|t|from|to)[\s_-]*([\d/ -]+)$@', strtolower(urldecode($v)), $m)) {


### PR DESCRIPTION
As observed in https://github.com/s9y/Serendipity/issues/877, the second comments page was always empty. This PR fixes those pages by restoring the pagination detection.