### PR TITLE
Proposal: Set default value of captchas to off

### DIFF
--- a/plugins/serendipity_event_spamblock/ChangeLog
+++ b/plugins/serendipity_event_spamblock/ChangeLog
@@ -1,3 +1,5 @@
+1.89.7: Change the default for captchas to off, for accessibility
+
 1.89.6: More PHP 8 compatibility fixes
 
 1.89.3: PHP 8 compatibility

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -239,7 +239,7 @@ class serendipity_event_spamblock extends serendipity_event
                 $propbag->add('type', 'radio');
                 $propbag->add('name', PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS);
                 $propbag->add('description', PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_DESC);
-                $propbag->add('default', 'yes');
+                $propbag->add('default', 'no');
                 $propbag->add('radio', array(
                     'value' => array(true, 'no', 'scramble'),
                     'desc'  => array(YES, NO, PLUGIN_EVENT_SPAMBLOCK_CAPTCHAS_SCRAMBLE)

--- a/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
+++ b/plugins/serendipity_event_spamblock/serendipity_event_spamblock.php
@@ -27,7 +27,7 @@ class serendipity_event_spamblock extends serendipity_event
             'smarty'      => '2.6.7',
             'php'         => '4.1.0'
         ));
-        $propbag->add('version',       '1.89.6');
+        $propbag->add('version',       '1.89.7');
         $propbag->add('event_hooks',    array(
             'frontend_saveComment' => true,
             'external_plugin'      => true,


### PR DESCRIPTION
As a minimally invasive change, I would like to change the default of the captchas to disable them. 

Captchas are no deterrent to bots anymore, or only block the lowest effort bot out there. But they still are an accessibility problem. To reduce their harmfulness, we can disable them by default, which might make some blogs out there not enable them.

As an alternative proposal, maybe a follow-up, I would replace them with a question. Like "What is 1 + 1", maybe even a small selection of questions . This will also not block all bots, but it would have the same effect of blocking the lowest effort bots. Probably would be a drop-in replacement.

Alternative to the alternative proposal: Just remove them completely. We do have bayes and spamblock bee and the other spam measures of the spamblock plugin, options that work better and are less harmful.

What do you think? @garvinhicking ?