### PR TITLE
Add a xslt sylesheet to the rss and atom feed

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.6-beta2 ()
 ------------------------------------------------------------------------
 
+   * Add XSLT shylesheet to the RSS 2.0 feed, including a link to an
+     explainer about how to use feeds
+
 Version 2.6-beta1 (July 31th, 2025)
 ------------------------------------------------------------------------
 

--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,7 +1,7 @@
 Version 2.6-beta2 ()
 ------------------------------------------------------------------------
 
-   * Add XSLT shylesheet to the RSS 2.0 feed, including a link to an
+   * Add XSLT shylesheet to the RSS and Atom feed, including a link to an
      explainer about how to use feeds
 
 Version 2.6-beta1 (July 31th, 2025)

--- a/rss.php
+++ b/rss.php
@@ -278,7 +278,7 @@ switch($version) {
     case '1.0':
         $namespace_hook = 'frontend_display:rss-1.0:namespace';
         serendipity_plugin_api::hook_event('frontend_display:rss-1.0:once', $entries);
-        $once_display_dat = $entries['display_dat'];
+        $once_display_dat = $entries['display_dat'] ?? '';
         unset($entries['display_dat']);
         break;
 

--- a/templates/2k11/atom.xsl
+++ b/templates/2k11/atom.xsl
@@ -17,11 +17,19 @@
 
 			<link rel="shortcut icon" type="image/ico" href="{ link }favicon.png" />
 			<link rel="stylesheet" href="{ link }index.php?/serendipity.css" />
+			<style>
+				.rss_header {
+					background: #a5e7d9;
+					border: 2px solid #58afd9;
+					margin-top: 0.5em;
+					padding: 0.5em;
+				}
+			</style>
 		</head>
 		<body>
 			<div id="page" class="container">
-				<header id="banner" class="page_header serendipity_entry">
-					Subscribe to this feed with a feedreader to get notifications about new articles. See <a href="https://aboutfeeds.com/">this explanation</a>, if you need help.
+				<header id="banner" class="serendipity_entry">
+					<p class="rss_header">Subscribe to this feed with a feedreader to get notifications about new articles. See <a href="https://aboutfeeds.com/">this explanation</a>, if you need help.</p>
 
 					<h1 class="title">
 						<xsl:value-of select="atom:title" />

--- a/templates/2k11/atom.xsl
+++ b/templates/2k11/atom.xsl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:atom="http://www.w3.org/2005/Atom">
+
+	<xsl:output method="html" indent="yes" encoding="UTF-8"/>
+
+	<xsl:template match="/atom:feed">
+
+		<html lang="en">
+		<head>
+			<meta charset="utf-8" />
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+			<title>
+				<xsl:value-of select="atom:title" />
+			</title>
+
+			<link rel="shortcut icon" type="image/ico" href="{ link }favicon.png" />
+			<link rel="stylesheet" href="{ link }index.php?/serendipity.css" />
+		</head>
+		<body>
+			<div id="page" class="container">
+				<header id="banner" class="page_header serendipity_entry">
+					Subscribe to this feed with a feedreader to get notifications about new articles. See <a href="https://aboutfeeds.com/">this explanation</a>, if you need help.
+
+					<h1 class="title">
+						<xsl:value-of select="atom:title" />
+					</h1>
+				</header>
+
+				<p class="description serendipity_entry">
+					<xsl:value-of select="atom:subtitle" />
+				</p>
+				
+				<main id="content">
+					<xsl:for-each select="atom:entry">
+
+						<article class="serendipity_entry">
+
+							<h2 class="post_title">
+								<a href="{atom:link[@rel='alternate']/@href}" class="post_link">
+									<xsl:value-of select="atom:title" />
+								</a>
+							</h2>
+
+							<p class="post_preview">
+								<xsl:value-of select="atom:content" disable-output-escaping="yes" />
+							</p>
+						</article>
+
+					</xsl:for-each>
+				</main>
+			</div>
+		</body>
+		</html>
+
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/templates/2k11/feed_0.91.tpl
+++ b/templates/2k11/feed_0.91.tpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
+<?xml-stylesheet type="text/xsl" href="{serendipity_getFile file="rss.xsl"}" media="screen" ?>
 <rss version="0.91" {$namespace_display_dat}>
 <channel>
 <title>{$metadata.title}</title>

--- a/templates/2k11/feed_2.0.tpl
+++ b/templates/2k11/feed_2.0.tpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
-<?xml-stylesheet type="text/xsl" href="{$serendipityBaseURL}templates/2k11/rss.xsl" media="screen" ?>
+<?xml-stylesheet type="text/xsl" href="{serendipity_getFile file="rss.xsl"}" media="screen" ?>
 <rss version="2.0" 
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:admin="http://webns.net/mvcb/"

--- a/templates/2k11/feed_2.0.tpl
+++ b/templates/2k11/feed_2.0.tpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
+<?xml-stylesheet type="text/xsl" href="{$serendipityBaseURL}templates/2k11/rss.xsl" media="screen" ?>
 <rss version="2.0" 
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:admin="http://webns.net/mvcb/"

--- a/templates/2k11/feed_atom1.0.tpl
+++ b/templates/2k11/feed_atom1.0.tpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
+<?xml-stylesheet type="text/xsl" href="{serendipity_getFile file="atom.xsl"}" media="screen" ?>
 <feed {$namespace_display_dat}
    xmlns="http://www.w3.org/2005/Atom"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"

--- a/templates/2k11/rss.xsl
+++ b/templates/2k11/rss.xsl
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:admin="http://webns.net/mvcb/"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+   xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+   xmlns:content="http://purl.org/rss/1.0/modules/content/">
+
+	<xsl:output method="html" doctype-system="about:legacy-compat" indent="yes" />
+
+	<xsl:template match="/rss/channel">
+
+		<html lang="en">
+		<head>
+			<meta charset="utf-8" />
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+			<title>
+				<xsl:value-of select="title" />
+			</title>
+
+			<link rel="shortcut icon" type="image/ico" href="{ link }favicon.png" />
+			<link rel="stylesheet" href="{ link }index.php?/serendipity.css" />
+		</head>
+		<body>
+			<div id="page" class="container">
+				<header id="banner" class="page_header serendipity_entry">
+					Subscribe to this feed with a feedreader to get notifications about new articles. See <a href="https://aboutfeeds.com/">this explanation</a>, if you need help.
+
+					<h1 class="title">
+						<xsl:value-of select="title" />
+					</h1>
+				</header>
+
+				
+
+				<p class="description serendipity_entry">
+					<xsl:value-of select="description" />
+				</p>
+				
+				
+				<main id="content">
+					<xsl:for-each select="./item">
+
+						<article class="serendipity_entry">
+
+							<h2 class="post_title">
+								<a href="{ link }" class="post_link">
+									<xsl:value-of select="title" />
+								</a>
+							</h2>
+
+							<p class="post_preview">
+								<xsl:value-of select="content:encoded" disable-output-escaping="yes" />
+							</p>
+						</article>
+
+					</xsl:for-each>
+				</main>
+			</div>
+		</body>
+		</html>
+
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/templates/2k11/rss.xsl
+++ b/templates/2k11/rss.xsl
@@ -22,11 +22,19 @@
 
 			<link rel="shortcut icon" type="image/ico" href="{ link }favicon.png" />
 			<link rel="stylesheet" href="{ link }index.php?/serendipity.css" />
+			<style>
+				.rss_header {
+					background: #a5e7d9;
+					border: 2px solid #58afd9;
+					margin-top: 0.5em;
+					padding: 0.5em;
+				}
+			</style>
 		</head>
 		<body>
 			<div id="page" class="container">
-				<header id="banner" class="page_header serendipity_entry">
-					Subscribe to this feed with a feedreader to get notifications about new articles. See <a href="https://aboutfeeds.com/">this explanation</a>, if you need help.
+				<header id="banner" class="serendipity_entry">
+					<p class="rss_header">Subscribe to this feed with a feedreader to get notifications about new articles. See <a href="https://aboutfeeds.com/">this explanation</a>, if you need help.</p>
 
 					<h1 class="title">
 						<xsl:value-of select="title" />

--- a/templates/2k11/rss.xsl
+++ b/templates/2k11/rss.xsl
@@ -52,6 +52,10 @@
 							</h2>
 
 							<p class="post_preview">
+								<xsl:value-of select="description" disable-output-escaping="yes" />
+							</p>
+
+							<p class="post_content">
 								<xsl:value-of select="content:encoded" disable-output-escaping="yes" />
 							</p>
 						</article>


### PR DESCRIPTION
By adding the xslt stylesheet, the feed looks a lot better in browsers.

The stylesheet applies the blog css, so it will mirror the design of the regular articles. I picked html classes and ids so it works fine with 2k11 and Skeleton, so this should work well as default in a number of themes. 

This links to https://aboutfeeds.com/ for now, but unlike as proposed in https://github.com/s9y/Serendipity/pull/807 it does not use their proprietary XSLT template, nor is the XSLT template based on theirs. We could also link to a different helper site of course.

One remaining issue is the rendering of our content:encoded. In XSLT 1.0, the old standard browser support (so far), there is no way to do that but the nonstandard `disable-output-escaping="yes"`. Which Chromium understands, but Firefox does not. But even with raw HTML this still looks better in Firefox than the arcane XML syntax shown before.

~~This approach could be extended to our RSS 1.0 feed, or probably at least the Atom feed would be nice, as that one is used quite a bit.~~ <-- Done

If XSLT is really [removed from browsers](https://github.com/whatwg/html/pull/11563) in the future we would have to add a polyfill, which would suck. We should use the feature anyway as long as we can.

Tested the rendering in Firefox and Chromium, and with FreshRSS that the feed is still understood as feed.