### PR TITLE
Let users provide a list of valid hosts for autodetected base URLs 

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,11 @@
 Version 2.6-beta2 ()
 ------------------------------------------------------------------------
 
+   * Add an option to limit which hosts are accepted as automatically
+     detected baseURL, serendipity['validBaseHosts']. This is a security
+     measure for installations that run under multiple domains and also
+     accept arbitrary host headers.
+
    * Rework of the XSRF token protection, it was a replaced with a 
      check on the Sec-Fetch-Site header. This should eliminate the
      timeouts that caused referer error messages on entry previews and

--- a/include/tpl/config_local.inc.php
+++ b/include/tpl/config_local.inc.php
@@ -132,6 +132,13 @@
                                           'permission'  => 'siteConfiguration',
                                           'default'     => false),
 
+                                    array('var'         => 'validBaseHosts',
+                                          'title'       => INSTALL_AUTODETECT_VALID_HOSTS,
+                                          'description' => INSTALL_AUTODETECT_VALID_HOSTS_DESC,
+                                          'type'        => 'string',
+                                          'permission'  => 'siteConfiguration',
+                                          'default'     => ''),
+
                                     array('var'         => 'indexFile',
                                           'title'       => INSTALL_INDEXFILE,
                                           'description' => INSTALL_INDEXFILE_DESC,

--- a/lang/UTF-8/serendipity_lang_bg.inc.php
+++ b/lang/UTF-8/serendipity_lang_bg.inc.php
@@ -683,6 +683,8 @@ $i18n_filename_to   = array('-', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('INSTALL_URL_DESC', 'Основен URL на вашата инсталация на Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Автоматично откриване на използвания HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ако е "да", Serendipity ще се подсигури, че използвания от посетителя HTTP Host ще бъде използван като настройката BaseURL. Активирането на това ще позволи да имате няколко домейн имена за вашия блог на Serendipity и ще бъде използван съответния домейн за проследяващи връзки, използвани от вашия блог.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Индексен файл');
 @define('INSTALL_INDEXFILE_DESC', 'Името на вашия индексен файл на Serendipity');
 

--- a/lang/UTF-8/serendipity_lang_cn.inc.php
+++ b/lang/UTF-8/serendipity_lang_cn.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', '系统安装的基本地址');
 @define('INSTALL_AUTODETECT_URL', '自动检测 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果设定为 "true"，HTTP Host 跟基本的地址设定相同。开启这项功能可以允许你使用多个的域名的日志和使用这个日志域名连接。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 文件');
 @define('INSTALL_INDEXFILE_DESC', '系统的 index 文件');
 

--- a/lang/UTF-8/serendipity_lang_cs.inc.php
+++ b/lang/UTF-8/serendipity_lang_cs.inc.php
@@ -709,6 +709,8 @@ $i18n_filename_to = array (
 @define('INSTALL_URL_DESC', 'Základní URL vaší instalace Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetekce použité HTTP hostitelské adresy');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Při volbě "Ano" bude Serendipity předpokládat, že HTTP adresa hostitele, použitá návštěvníkem, je vaše základní nastavení URL. Zapnutí umožní používání různých domén k přístupu na vaše stránky, a použití této jedné domény pro všechny odkazy ke sledování změn na stránkách.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexový soubor');
 @define('INSTALL_INDEXFILE_DESC', 'Název souboru použitého jako index');
 

--- a/lang/UTF-8/serendipity_lang_cz.inc.php
+++ b/lang/UTF-8/serendipity_lang_cz.inc.php
@@ -709,6 +709,8 @@ $i18n_filename_to = array (
 @define('INSTALL_URL_DESC', 'Základní URL vaší instalace Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetekce použité HTTP hostitelské adresy');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Při volbě "Ano" bude Serendipity předpokládat, že HTTP adresa hostitele, použitá návštěvníkem, je vaše základní nastavení URL. Zapnutí umožní používání různých domén k přístupu na vaše stránky, a použití této jedné domény pro všechny odkazy ke sledování změn na stránkách.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexový soubor');
 @define('INSTALL_INDEXFILE_DESC', 'Název souboru použitého jako index');
 

--- a/lang/UTF-8/serendipity_lang_da.inc.php
+++ b/lang/UTF-8/serendipity_lang_da.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', 'Grund URL for din Serendipity installation');
 @define('INSTALL_AUTODETECT_URL', 'Autoudregn anvendt HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Hvis denne er sat til "ja", vil Serendipity sikre at den HTTP Host der anvendes af dine besøgende, anvendes som din BaseURL indstilling. Aktiverer du dette, kan du bruge flere domænenavne på samme Serendipity Blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index fil');
 @define('INSTALL_INDEXFILE_DESC', 'Navnet på din Serendipity index fil');
 

--- a/lang/UTF-8/serendipity_lang_de.inc.php
+++ b/lang/UTF-8/serendipity_lang_de.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Stamm-URL zur Serendipity-Installation');
 @define('INSTALL_AUTODETECT_URL', 'HTTP-Hostnamen automatisch erkennen');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Falls aktiviert, wird Serendipity sicherstellen, dass der vom Besucher gewählte HTTP-Hostname als BaseURL-Variable verwendet wird. Sofern diese Option aktiviert ist, ist es möglich, mehrere Domainnamen für das Weblog zu verwenden. Alle Links werden dann mit dem HTTP-Hostnamen umgeschrieben, der vom Besucher gewählt wurde.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Erlaubte automatische HTTP-Hostnamen');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Eine kommaseaparierte Liste erlaubter Hostnamen. Nur diese würden in automatisch erkannten Stamm-URLs akzeptiert. Das ist eine Sicherheitsoption für Server, die auf beliebige HTTO-Hostheader reagieren..');
 @define('INSTALL_INDEXFILE', 'Index-Datei');
 @define('INSTALL_INDEXFILE_DESC', 'Welche Datei wird als Index-Datei verwendet (index.php)');
 

--- a/lang/UTF-8/serendipity_lang_en.inc.php
+++ b/lang/UTF-8/serendipity_lang_en.inc.php
@@ -677,6 +677,8 @@
 @define('INSTALL_URL_DESC', 'Base URL to your serendipity installation');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index file');
 @define('INSTALL_INDEXFILE_DESC', 'The name of your serendipity index file');
 

--- a/lang/UTF-8/serendipity_lang_es.inc.php
+++ b/lang/UTF-8/serendipity_lang_es.inc.php
@@ -689,6 +689,8 @@
 @define('INSTALL_URL_DESC', 'URL base de tu instalación de serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectar HTTP-Host usado');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Si se configura como "Sí", Serendipity asegurará que el nombre de Host HTTP que usó por tu visitante para acceder al blog se usa como la URL base. Activando esto te permitirá usar varios nombres de dominio para tu blog, y usar ese dominio para todos los enlaces que siga el usuario.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Fichero índice');
 @define('INSTALL_INDEXFILE_DESC', 'El nombre del fichero índice de serendipity');
 

--- a/lang/UTF-8/serendipity_lang_fa.inc.php
+++ b/lang/UTF-8/serendipity_lang_fa.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'آدرس اصلی نصب سرندیپیتی');
 @define('INSTALL_AUTODETECT_URL', 'تشخیص خودکار استفاده از HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'اگر روی "بله" تنظیم شود، سرندیپیتی قرار داشتن آدرس BaseURL که در بخش تنظیمات وارد کرده اید را در درخواست ارسالی بررسی می کند. فعال کردن این گزینه، باعث می شود که شما بتوانید از چندین دامنه برای دیدن وبلاگ سرندیپیتی و تمامی لینک های وابسته به آن استفاده کنید.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'فایل فهرست');
 @define('INSTALL_INDEXFILE_DESC', 'نام فایل فهرست (index) شما');
 

--- a/lang/UTF-8/serendipity_lang_fi.inc.php
+++ b/lang/UTF-8/serendipity_lang_fi.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Serendipity-asennuksen osoite');
 @define('INSTALL_AUTODETECT_URL', 'Havaitse käytetty HTTP-isäntä automaattisesti');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Jos valitset kyllä, Serendipity käyttää vierailijan käyttämäää HTTP-isäntänimeä BaseURL:ina. Tätä käyttämällä voit antaa blogillesi useamman verkkonimen ja käyttää samaa verkkonimeä kaikissa linkeissä, joita vierailija käyttää lukiessaan blogiasi.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Aloitustiedosto');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipityn aloitustiedoston nimi');
 

--- a/lang/UTF-8/serendipity_lang_fr.inc.php
+++ b/lang/UTF-8/serendipity_lang_fr.inc.php
@@ -681,6 +681,8 @@
 @define('INSTALL_URL_DESC', 'Le lien (URL) pour accéder à votre installation de Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodétection utilisée HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Si positionné à "true", Serendipity s\'assurera que l\'hôte HTTP qui a été utilisé par le visiteur utilise les réglages de votre base d\'URLs. Autoriser cela vous permettra d\'utiliser plusieurs noms de domaines pour votre blog Serendipity, et utilisera le domaine pour tout les liens suivants utilisés par le visiteur pour accéder à votre blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Script principal');
 @define('INSTALL_INDEXFILE_DESC', 'Le nom du script principal que vous voulez utiliser pour Serendipity (exemple: index.php)');
 

--- a/lang/UTF-8/serendipity_lang_hu.inc.php
+++ b/lang/UTF-8/serendipity_lang_hu.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'A blog-od URL-je');
 @define('INSTALL_AUTODETECT_URL', 'HTTP-Hoszt automatikus meghatározása');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ha ez "igen"-re van állítva, akkor a látogató által használt domain név kerül használatra  az általad beállított BaseURL helyett. Ezzel a beállítással több domain-es környezetben is használhatod a Serendipity blog-ot, így nem okoz gondot a linkek kezelése.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index fájl');
 @define('INSTALL_INDEXFILE_DESC', 'A serendipity-d index fájlja');
 

--- a/lang/UTF-8/serendipity_lang_is.inc.php
+++ b/lang/UTF-8/serendipity_lang_is.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Grunnslóðin (Base URL) á serendipity uppsetninguna þína');
 @define('INSTALL_AUTODETECT_URL', 'Skynja sjálfvirkt HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ef þetta er stillt á "true" mun Serendipity sjá til þess að HTTP Host nafnið sem var notað sé notað sem BaseURL stilling. Að virkja þetta mun gera þér kleift að nota mörg mismunandi vélarnöfn fyrir Serendipity bloggið þitt, og nota það vélarnafn fyrir alla tengla fyrir alla tengla eftir það sem eru notaðir til að vafra um bloggið þitt.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index skrá');
 @define('INSTALL_INDEXFILE_DESC', 'Nafnið á serendipity index skránni þinni');
 

--- a/lang/UTF-8/serendipity_lang_it.inc.php
+++ b/lang/UTF-8/serendipity_lang_it.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'URL di base all\'installazione di serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autoriconoscimento dell\'HTTP-Host utilizzato');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Se impostato a "vero", Serendipity controllerà che l\'Host HTTP usato dal tuo visitatore sia usato come la tua impostazione BaseURL. Ablitando questo sarai in grado di utilizzare nomi di dominio multipli per il tuo Blog Serendipity, anare il dominio per tutti i links di follow-up che l\'utente ha usato per accedere al tuo blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'File indice');
 @define('INSTALL_INDEXFILE_DESC', 'Il nome del file indice di serendipity');
 

--- a/lang/UTF-8/serendipity_lang_ja.inc.php
+++ b/lang/UTF-8/serendipity_lang_ja.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'serendipity をインストールしたベース URL');
 @define('INSTALL_AUTODETECT_URL', '自動検知に HTTP-Host を使う');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'インデックスファイル');
 @define('INSTALL_INDEXFILE_DESC', 'serendipity インデックスファイルの名前');
 

--- a/lang/UTF-8/serendipity_lang_ko.inc.php
+++ b/lang/UTF-8/serendipity_lang_ko.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', '세렌디피티가 설치된 기본 인터넷 주소(URL)');
 @define('INSTALL_AUTODETECT_URL', '사용된 HTTP 호스트를 자동 감지');
 @define('INSTALL_AUTODETECT_URL_DESC', '사용할 경우 방문자가 사용한 HTTP 호스트를 세렌디피티가 기본 인터넷 주소로 쓰게 됩니다. 이렇게 되면 세렌디피티 블로그를 여러 개의 도메인 이름 하에 사용할 수 있게 되며, 해당 도메인을 방문자가 블로그를 방문하는데 사용한 추가 링크에 사용할 수 있게 됩니다.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', '인덱스 파일');
 @define('INSTALL_INDEXFILE_DESC', '세렌디피티 인덱스 파일의 이름');
 

--- a/lang/UTF-8/serendipity_lang_nl.inc.php
+++ b/lang/UTF-8/serendipity_lang_nl.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', 'De URL naar uw Serendipity-installatie');
 @define('INSTALL_AUTODETECT_URL', 'Automatisch detecteren van HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Als dit aan staat, dan zal Serendipity er voor zorgen dat de HTTP-Host die werd gebruikt door uw bezoeker gezet zal worden als uw basis-URL. Hierdoor wordt het mogelijk zijn om meerdere domeinnamen te gebruiken voor uw weblog en het domein gebruiken voor alle hyperlinks in uw weblog binnen die sessie.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexbestand');
 @define('INSTALL_INDEXFILE_DESC', 'De naam van uw Serendipity-indexbestand');
 

--- a/lang/UTF-8/serendipity_lang_no.inc.php
+++ b/lang/UTF-8/serendipity_lang_no.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Base-URL for din Serendipity-installasjon');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index-fil');
 @define('INSTALL_INDEXFILE_DESC', 'Navnet på din Serendipity index-fil');
 

--- a/lang/UTF-8/serendipity_lang_pl.inc.php
+++ b/lang/UTF-8/serendipity_lang_pl.inc.php
@@ -679,6 +679,8 @@ $i18n_filename_to   = array('_', 'a', 'A', 'a', 'A', 'b', 'B', 'c', 'C', 'c', 'C
 @define('INSTALL_URL_DESC', 'Bazowy URL instalacji Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Plik index');
 @define('INSTALL_INDEXFILE_DESC', 'Nazwa pliku index Twojego Serendipity');
 

--- a/lang/UTF-8/serendipity_lang_pt.inc.php
+++ b/lang/UTF-8/serendipity_lang_pt.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'URL base para a instalação do serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectar usando HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Se marcado "true", o Serendipity assegurará que o HTTP Host que é usado pelo seu visitante é usado como definição de BaseURL. Permitir isto possibilita usar vários nomes de domínio para o seu blog, e usar o domínio para todos os links subseqüentes.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Arquivo inicial');
 @define('INSTALL_INDEXFILE_DESC', 'Nome do arquivo inicial do serendipity');
 

--- a/lang/UTF-8/serendipity_lang_pt_PT.inc.php
+++ b/lang/UTF-8/serendipity_lang_pt_PT.inc.php
@@ -681,6 +681,8 @@
 @define('INSTALL_URL_DESC', 'URL base para a instalação do Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectar HTTP-Host utilizado');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Se definido como "true", o Serendipity assegurará que o HTTP Host que é usado pelo seu visitante é usado como definição de BaseURL. Permitir isto torna possível usar vários nomes de domínio para o seu blogue Serendipity, e usar o domínio para todas as ligações subsequentes.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Arquivo inicial');
 @define('INSTALL_INDEXFILE_DESC', 'Nome do arquivo inicial do Serendipity');
 

--- a/lang/UTF-8/serendipity_lang_ro.inc.php
+++ b/lang/UTF-8/serendipity_lang_ro.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'URL de baza catre instalarea serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectie adresa HTTP');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Daca e activata, Serendipity va verifica ca adresa HTTP folosita de cititor sa corespunda cu optiunea ta BaseURL. Activând aceasta optiune vei putea folosi mai multe domenii pentru acest blog, si sa folosesti domeniul pentru toate legaturile de pe acest blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Fisier index');
 @define('INSTALL_INDEXFILE_DESC', 'Numele fisierului index pentru serendipity');
 

--- a/lang/UTF-8/serendipity_lang_ru.inc.php
+++ b/lang/UTF-8/serendipity_lang_ru.inc.php
@@ -680,6 +680,8 @@ $i18n_filename_to   = array('_', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('INSTALL_URL_DESC', 'Основной URL Вашего блога');
 @define('INSTALL_AUTODETECT_URL', 'Автоматически определять HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Если установлено "Да", Serendipity будет пытаться определить HTTP-Host, который был использован пользователем при обращении, как Ваш базовый URL. Активация этой опции позволит Вам использовать множество доменных имен для Вашего блога Serendipity и использовать доменное имя для всех пересылающих ссылок, использованных для доступа к Вашему блогу.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Индексный файл');
 @define('INSTALL_INDEXFILE_DESC', 'Имя индексного файла Вашего блога');
 

--- a/lang/UTF-8/serendipity_lang_sa.inc.php
+++ b/lang/UTF-8/serendipity_lang_sa.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'الرابط الاساسي لتثبيت و تركيب المجلة. الانستوليشن');
 @define('INSTALL_AUTODETECT_URL', 'التعرف التلقائي على نطاق (Domain) الموقع');
 @define('INSTALL_AUTODETECT_URL_DESC', 'أن أختر الخيار صحيح. سوف تتمكن المجلة من معرفة الرابط الذي يستخدمه الزوار على أنه الرابط الأساسي. باختيارك هذا الخيار يجعلك قادر على استخدام أكثر من أسم نطاق (دومين) للوصول إلى مدونتك. وسوف يستخدم أسم النطاق هذا لجميع الروابط التابعة للمدونة');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index file');
 @define('INSTALL_INDEXFILE_DESC', 'أسم ملف الاندكس للمدونة');
 

--- a/lang/UTF-8/serendipity_lang_se.inc.php
+++ b/lang/UTF-8/serendipity_lang_se.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Bas-URL till din Serendipity-installation');
 @define('INSTALL_AUTODETECT_URL', 'Känn igen HTTP-värd automatiskt');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Om satt till "true", kommer Serendipity se till att den HTTP-värd som användes av din besökare är din BaseURL-inställning. Om du aktiverar detta kommer du att kunna använda flera domännamn för din Serendipity Blogg och använda den domänen för uppföljande länkar som användaren använde för att få tillgång till din blogg.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index-fil');
 @define('INSTALL_INDEXFILE_DESC', 'Namnet på din index-fil för Serendipity');
 

--- a/lang/UTF-8/serendipity_lang_sk.inc.php
+++ b/lang/UTF-8/serendipity_lang_sk.inc.php
@@ -690,6 +690,8 @@ $i18n_filename_to = array (
 @define('INSTALL_URL_DESC', 'Základná URL Vašej inštalácie Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetekcia použitej HTTP adresy na serveri');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Pri voľbe "Áno" bude Serendipity predpokladať, že HTTP adresa použitá návštevníkom, je Vašé základné nastavenie URL. Zapnutie umožní používáníe rôznych domén k prístupu na Vaše stránky, a použitie téjto jednej domény pre všetky odkazy na sledovánie zmien na stránkách.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexový súbor');
 @define('INSTALL_INDEXFILE_DESC', 'Názov súboru použitého ako index');
 

--- a/lang/UTF-8/serendipity_lang_ta.inc.php
+++ b/lang/UTF-8/serendipity_lang_ta.inc.php
@@ -677,6 +677,8 @@
 @define('INSTALL_URL_DESC', 'இந்த வலைக்குறிப்பின் வலைமுகவரி');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'வலைக்குறிப்பின் முதற்பக்க மென்பொருள்');
 @define('INSTALL_INDEXFILE_DESC', 'வலைக்குறிப்பின் முதற்பக்க மென்பொருளின் பெயர்');
 

--- a/lang/UTF-8/serendipity_lang_tn.inc.php
+++ b/lang/UTF-8/serendipity_lang_tn.inc.php
@@ -680,6 +680,8 @@ $i18n_unknown = 'tw';
 @define('INSTALL_URL_DESC', '您的 Serendipity 安裝的基本 URL');
 @define('INSTALL_AUTODETECT_URL', '自動偵測 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果設定為 "true"，Serendipity 會確定讀者的 HTTP Host 跟您的基本 URL 設定相同。開啟這項功能可以允許您使用多數的網域名稱給您的網誌，和使用這個網域給跟進的連結。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 檔案');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipity 的 index 檔案');
 

--- a/lang/UTF-8/serendipity_lang_tr.inc.php
+++ b/lang/UTF-8/serendipity_lang_tr.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'Serendipity kurulumunuz için Temel URL adresi ');
 @define('INSTALL_AUTODETECT_URL', 'HTTP-Host Servisini otomatik belirle');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Eğer "true" olarak seçilirse, Serendipity ziyaretçilerin HTTP Host adresini sizin BaseURL ayarlarınıza göre kesin olarak belirleyebilecek.Bu seçenek açık olursa çoklu domain kullanma imkanına da sahip olursunuz, ve tüm izleyen bağlantılarda hangi kullanıcı hangi site bölümünüze erişmek istiyorsa erişebilir.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index dosyası');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipity index dosyasının adı');
 

--- a/lang/UTF-8/serendipity_lang_tw.inc.php
+++ b/lang/UTF-8/serendipity_lang_tw.inc.php
@@ -680,6 +680,8 @@ $i18n_unknown = 'tw';
 @define('INSTALL_URL_DESC', '您的 Serendipity 安裝的基本 URL');
 @define('INSTALL_AUTODETECT_URL', '自動偵測 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果設定為 "true"，Serendipity 會確定讀者的 HTTP Host 跟您的基本 URL 設定相同。開啟這項功能可以允許您使用多數的網域名稱給您的網誌，和使用這個網域給跟進的連結。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 檔案');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipity 的 index 檔案');
 

--- a/lang/UTF-8/serendipity_lang_zh.inc.php
+++ b/lang/UTF-8/serendipity_lang_zh.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', '系统安装的基本地址');
 @define('INSTALL_AUTODETECT_URL', '自动检测 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果设定为 "true"，HTTP Host 跟基本的地址设定相同。开启这项功能可以允许你使用多个的域名的日志和使用这个日志域名连接。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 文件');
 @define('INSTALL_INDEXFILE_DESC', '系统的 index 文件');
 

--- a/lang/serendipity_lang_bg.inc.php
+++ b/lang/serendipity_lang_bg.inc.php
@@ -683,6 +683,8 @@ $i18n_filename_to   = array('-', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('INSTALL_URL_DESC', 'Основен URL на вашата инсталация на Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Автоматично откриване на използвания HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ако е "да", Serendipity ще се подсигури, че използвания от посетителя HTTP Host ще бъде използван като настройката BaseURL. Активирането на това ще позволи да имате няколко домейн имена за вашия блог на Serendipity и ще бъде използван съответния домейн за проследяващи връзки, използвани от вашия блог.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Индексен файл');
 @define('INSTALL_INDEXFILE_DESC', 'Името на вашия индексен файл на Serendipity');
 

--- a/lang/serendipity_lang_cn.inc.php
+++ b/lang/serendipity_lang_cn.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', '系统安装的基本地址');
 @define('INSTALL_AUTODETECT_URL', '自动检测 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果设定为 "true"，HTTP Host 跟基本的地址设定相同。开启这项功能可以允许你使用多个的域名的日志和使用这个日志域名连接。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 文件');
 @define('INSTALL_INDEXFILE_DESC', '系统的 index 文件');
 

--- a/lang/serendipity_lang_cs.inc.php
+++ b/lang/serendipity_lang_cs.inc.php
@@ -709,6 +709,8 @@ $i18n_filename_to = array (
 @define('INSTALL_URL_DESC', 'Základní URL vaší instalace Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetekce použité HTTP hostitelské adresy');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Pøi volbì "Ano" bude Serendipity pøedpokládat, že HTTP adresa hostitele, použitá návštìvníkem, je vaše základní nastavení URL. Zapnutí umožní používání rùzných domén k pøístupu na vaše stránky, a použití této jedné domény pro všechny odkazy ke sledování zmìn na stránkách.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexový soubor');
 @define('INSTALL_INDEXFILE_DESC', 'Název souboru použitého jako index');
 

--- a/lang/serendipity_lang_cz.inc.php
+++ b/lang/serendipity_lang_cz.inc.php
@@ -709,6 +709,8 @@ $i18n_filename_to = array (
 @define('INSTALL_URL_DESC', 'Základní URL va¹í instalace Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetekce pou¾ité HTTP hostitelské adresy');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Pøi volbì "Ano" bude Serendipity pøedpokládat, ¾e HTTP adresa hostitele, pou¾itá náv¹tìvníkem, je va¹e základní nastavení URL. Zapnutí umo¾ní pou¾ívání rùzných domén k pøístupu na va¹e stránky, a pou¾ití této jedné domény pro v¹echny odkazy ke sledování zmìn na stránkách.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexový soubor');
 @define('INSTALL_INDEXFILE_DESC', 'Název souboru pou¾itého jako index');
 

--- a/lang/serendipity_lang_da.inc.php
+++ b/lang/serendipity_lang_da.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', 'Grund URL for din Serendipity installation');
 @define('INSTALL_AUTODETECT_URL', 'Autoudregn anvendt HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Hvis denne er sat til "ja", vil Serendipity sikre at den HTTP Host der anvendes af dine besøgende, anvendes som din BaseURL indstilling. Aktiverer du dette, kan du bruge flere domænenavne på samme Serendipity Blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index fil');
 @define('INSTALL_INDEXFILE_DESC', 'Navnet på din Serendipity index fil');
 

--- a/lang/serendipity_lang_de.inc.php
+++ b/lang/serendipity_lang_de.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Stamm-URL zur Serendipity-Installation');
 @define('INSTALL_AUTODETECT_URL', 'HTTP-Hostnamen automatisch erkennen');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Falls aktiviert, wird Serendipity sicherstellen, dass der vom Besucher gewählte HTTP-Hostname als BaseURL-Variable verwendet wird. Sofern diese Option aktiviert ist, ist es möglich, mehrere Domainnamen für das Weblog zu verwenden. Alle Links werden dann mit dem HTTP-Hostnamen umgeschrieben, der vom Besucher gewählt wurde.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Erlaubte automatische HTTP-Hostnamen');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Eine kommaseaparierte Liste erlaubter Hostnamen. Nur diese würden in automatisch erkannten Stamm-URLs akzeptiert. Das ist eine Sicherheitsoption für Server, die auf beliebige HTTO-Hostheader reagieren.');
 @define('INSTALL_INDEXFILE', 'Index-Datei');
 @define('INSTALL_INDEXFILE_DESC', 'Welche Datei wird als Index-Datei verwendet (index.php)');
 

--- a/lang/serendipity_lang_en.inc.php
+++ b/lang/serendipity_lang_en.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Base URL to your serendipity installation');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index file');
 @define('INSTALL_INDEXFILE_DESC', 'The name of your serendipity index file');
 

--- a/lang/serendipity_lang_es.inc.php
+++ b/lang/serendipity_lang_es.inc.php
@@ -690,6 +690,8 @@
 @define('INSTALL_URL_DESC', 'URL base de tu instalación de serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectar HTTP-Host usado');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Si se configura como "Sí", Serendipity asegurará que el nombre de Host HTTP que usó por tu visitante para acceder al blog se usa como la URL base. Activando esto te permitirá usar varios nombres de dominio para tu blog, y usar ese dominio para todos los enlaces que siga el usuario.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Fichero índice');
 @define('INSTALL_INDEXFILE_DESC', 'El nombre del fichero índice de serendipity');
 

--- a/lang/serendipity_lang_fa.inc.php
+++ b/lang/serendipity_lang_fa.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'آدرس اصلی نصب سرندیپیتی');
 @define('INSTALL_AUTODETECT_URL', 'تشخیص خودکار استفاده از HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'اگر روی "بله" تنظیم شود، سرندیپیتی قرار داشتن آدرس BaseURL که در بخش تنظیمات وارد کرده اید را در درخواست ارسالی بررسی می کند. فعال کردن این گزینه، باعث می شود که شما بتوانید از چندین دامنه برای دیدن وبلاگ سرندیپیتی و تمامی لینک های وابسته به آن استفاده کنید.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'فایل فهرست');
 @define('INSTALL_INDEXFILE_DESC', 'نام فایل فهرست (index) شما');
 

--- a/lang/serendipity_lang_fi.inc.php
+++ b/lang/serendipity_lang_fi.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Serendipity-asennuksen osoite');
 @define('INSTALL_AUTODETECT_URL', 'Havaitse käytetty HTTP-isäntä automaattisesti');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Jos valitset kyllä, Serendipity käyttää vierailijan käyttämäää HTTP-isäntänimeä BaseURL:ina. Tätä käyttämällä voit antaa blogillesi useamman verkkonimen ja käyttää samaa verkkonimeä kaikissa linkeissä, joita vierailija käyttää lukiessaan blogiasi.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Aloitustiedosto');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipityn aloitustiedoston nimi');
 

--- a/lang/serendipity_lang_fr.inc.php
+++ b/lang/serendipity_lang_fr.inc.php
@@ -681,6 +681,8 @@
 @define('INSTALL_URL_DESC', 'Le lien (URL) pour accéder à votre installation de Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodétection utilisée HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Si positionné à "true", Serendipity s\'assurera que l\'hôte HTTP qui a été utilisé par le visiteur utilise les réglages de votre base d\'URLs. Autoriser cela vous permettra d\'utiliser plusieurs noms de domaines pour votre blog Serendipity, et utilisera le domaine pour tout les liens suivants utilisés par le visiteur pour accéder à votre blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Script principal');
 @define('INSTALL_INDEXFILE_DESC', 'Le nom du script principal que vous voulez utiliser pour Serendipity (exemple: index.php)');
 

--- a/lang/serendipity_lang_hu.inc.php
+++ b/lang/serendipity_lang_hu.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'A blog-od URL-je');
 @define('INSTALL_AUTODETECT_URL', 'HTTP-Hoszt automatikus meghatározása');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ha ez "igen"-re van állítva, akkor a látogató által használt domain név kerül használatra  az általad beállított BaseURL helyett. Ezzel a beállítással több domain-es környezetben is használhatod a Serendipity blog-ot, így nem okoz gondot a linkek kezelése.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index fájl');
 @define('INSTALL_INDEXFILE_DESC', 'A serendipity-d index fájlja');
 

--- a/lang/serendipity_lang_is.inc.php
+++ b/lang/serendipity_lang_is.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Grunnslóðin (Base URL) á serendipity uppsetninguna þína');
 @define('INSTALL_AUTODETECT_URL', 'Skynja sjálfvirkt HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ef þetta er stillt á "true" mun Serendipity sjá til þess að HTTP Host nafnið sem var notað sé notað sem BaseURL stilling. Að virkja þetta mun gera þér kleift að nota mörg mismunandi vélarnöfn fyrir Serendipity bloggið þitt, og nota það vélarnafn fyrir alla tengla fyrir alla tengla eftir það sem eru notaðir til að vafra um bloggið þitt.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index skrá');
 @define('INSTALL_INDEXFILE_DESC', 'Nafnið á serendipity index skránni þinni');
 

--- a/lang/serendipity_lang_it.inc.php
+++ b/lang/serendipity_lang_it.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'URL di base all\'installazione di serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autoriconoscimento dell\'HTTP-Host utilizzato');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Se impostato a "vero", Serendipity controllerà che l\'Host HTTP usato dal tuo visitatore sia usato come la tua impostazione BaseURL. Ablitando questo sarai in grado di utilizzare nomi di dominio multipli per il tuo Blog Serendipity, anare il dominio per tutti i links di follow-up che l\'utente ha usato per accedere al tuo blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'File indice');
 @define('INSTALL_INDEXFILE_DESC', 'Il nome del file indice di serendipity');
 

--- a/lang/serendipity_lang_ja.inc.php
+++ b/lang/serendipity_lang_ja.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'serendipity をインストールしたベース URL');
 @define('INSTALL_AUTODETECT_URL', '自動検知に HTTP-Host を使う');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'インデックスファイル');
 @define('INSTALL_INDEXFILE_DESC', 'serendipity インデックスファイルの名前');
 

--- a/lang/serendipity_lang_ko.inc.php
+++ b/lang/serendipity_lang_ko.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', '세렌디피티가 설치된 기본 인터넷 주소(URL)');
 @define('INSTALL_AUTODETECT_URL', '사용된 HTTP 호스트를 자동 감지');
 @define('INSTALL_AUTODETECT_URL_DESC', '사용할 경우 방문자가 사용한 HTTP 호스트를 세렌디피티가 기본 인터넷 주소로 쓰게 됩니다. 이렇게 되면 세렌디피티 블로그를 여러 개의 도메인 이름 하에 사용할 수 있게 되며, 해당 도메인을 방문자가 블로그를 방문하는데 사용한 추가 링크에 사용할 수 있게 됩니다.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', '인덱스 파일');
 @define('INSTALL_INDEXFILE_DESC', '세렌디피티 인덱스 파일의 이름');
 

--- a/lang/serendipity_lang_nl.inc.php
+++ b/lang/serendipity_lang_nl.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', 'De URL naar uw Serendipity-installatie');
 @define('INSTALL_AUTODETECT_URL', 'Automatisch detecteren van HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Als dit aan staat, dan zal Serendipity er voor zorgen dat de HTTP-Host die werd gebruikt door uw bezoeker gezet zal worden als uw basis-URL. Hierdoor wordt het mogelijk zijn om meerdere domeinnamen te gebruiken voor uw weblog en het domein gebruiken voor alle hyperlinks in uw weblog binnen die sessie.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexbestand');
 @define('INSTALL_INDEXFILE_DESC', 'De naam van uw Serendipity-indexbestand');
 

--- a/lang/serendipity_lang_no.inc.php
+++ b/lang/serendipity_lang_no.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Base-URL for din Serendipity-installasjon');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index-fil');
 @define('INSTALL_INDEXFILE_DESC', 'Navnet på din Serendipity index-fil');
 

--- a/lang/serendipity_lang_pl.inc.php
+++ b/lang/serendipity_lang_pl.inc.php
@@ -679,6 +679,8 @@ $i18n_filename_to   = array('_', 'a', 'A', 'a', 'A', 'b', 'B', 'c', 'C', 'c', 'C
 @define('INSTALL_URL_DESC', 'Bazowy URL instalacji Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Plik index');
 @define('INSTALL_INDEXFILE_DESC', 'Nazwa pliku index Twojego Serendipity');
 

--- a/lang/serendipity_lang_pt.inc.php
+++ b/lang/serendipity_lang_pt.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'URL base para a instalação do serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectar usando HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Se marcado "true", o Serendipity assegurará que o HTTP Host que é usado pelo seu visitante é usado como definição de BaseURL. Permitir isto possibilita usar vários nomes de domínio para o seu blog, e usar o domínio para todos os links subseqüentes.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Arquivo inicial');
 @define('INSTALL_INDEXFILE_DESC', 'Nome do arquivo inicial do serendipity');
 

--- a/lang/serendipity_lang_pt_PT.inc.php
+++ b/lang/serendipity_lang_pt_PT.inc.php
@@ -681,6 +681,8 @@
 @define('INSTALL_URL_DESC', 'URL base para a instalação do Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectar HTTP-Host utilizado');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Se definido como "true", o Serendipity assegurará que o HTTP Host que é usado pelo seu visitante é usado como definição de BaseURL. Permitir isto torna possível usar vários nomes de domínio para o seu blogue Serendipity, e usar o domínio para todas as ligações subsequentes.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Arquivo inicial');
 @define('INSTALL_INDEXFILE_DESC', 'Nome do arquivo inicial do Serendipity');
 

--- a/lang/serendipity_lang_ro.inc.php
+++ b/lang/serendipity_lang_ro.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'URL de baza catre instalarea serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetectie adresa HTTP');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Daca e activata, Serendipity va verifica ca adresa HTTP folosita de cititor sa corespunda cu optiunea ta BaseURL. Activând aceasta optiune vei putea folosi mai multe domenii pentru acest blog, si sa folosesti domeniul pentru toate legaturile de pe acest blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Fisier index');
 @define('INSTALL_INDEXFILE_DESC', 'Numele fisierului index pentru serendipity');
 

--- a/lang/serendipity_lang_ru.inc.php
+++ b/lang/serendipity_lang_ru.inc.php
@@ -680,6 +680,8 @@ $i18n_filename_to   = array('_', 'a', 'A', 'b', 'B', 'v', 'V', 'g', 'G', 'd', 'D
 @define('INSTALL_URL_DESC', 'Основной URL Вашего блога');
 @define('INSTALL_AUTODETECT_URL', 'Автоматически определять HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Если установлено "Да", Serendipity будет пытаться определить HTTP-Host, который был использован пользователем при обращении, как Ваш базовый URL. Активация этой опции позволит Вам использовать множество доменных имен для Вашего блога Serendipity и использовать доменное имя для всех пересылающих ссылок, использованных для доступа к Вашему блогу.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Индексный файл');
 @define('INSTALL_INDEXFILE_DESC', 'Имя индексного файла Вашего блога');
 

--- a/lang/serendipity_lang_sa.inc.php
+++ b/lang/serendipity_lang_sa.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'ÇבÑÇÈØ ÇבÇÓÇÓם בÊËÈםÊ ז ÊÑ‗םÈ ÇבדÌבÉ. ÇבÇהÓÊזבםÔה');
 @define('INSTALL_AUTODETECT_URL', 'ÇבÊÚÑÝ ÇבÊבÞÇÆם Úבל הØÇÞ (Domain) ÇבדזÞÚ');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Ãה ÃÎÊÑ ÇבÎםÇÑ ÕÍםÍ. ÓזÝ ÊÊד‗ה ÇבדÌבÉ דה דÚÑÝÉ ÇבÑÇÈØ ÇבÐם םÓÊÎÏדו ÇבÒזÇÑ Úבל Ãהו ÇבÑÇÈØ ÇבÃÓÇÓם. ÈÇÎÊםÇÑ‗ וÐÇ ÇבÎםÇÑ םÌÚב‗ ÞÇÏÑ Úבל ÇÓÊÎÏÇד Ã‗ËÑ דה ÃÓד הØÇÞ (Ïזדםה) בבזÕזב Åבל דÏזהÊ‗. זÓזÝ םÓÊÎÏד ÃÓד ÇבהØÇÞ וÐÇ בÌדםÚ ÇבÑזÇÈØ ÇבÊÇÈÚÉ בבדÏזהÉ');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index file');
 @define('INSTALL_INDEXFILE_DESC', 'ÃÓד דבÝ ÇבÇהÏ‗Ó בבדÏזהÉ');
 

--- a/lang/serendipity_lang_se.inc.php
+++ b/lang/serendipity_lang_se.inc.php
@@ -678,6 +678,8 @@
 @define('INSTALL_URL_DESC', 'Bas-URL till din Serendipity-installation');
 @define('INSTALL_AUTODETECT_URL', 'Känn igen HTTP-värd automatiskt');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Om satt till "true", kommer Serendipity se till att den HTTP-värd som användes av din besökare är din BaseURL-inställning. Om du aktiverar detta kommer du att kunna använda flera domännamn för din Serendipity Blogg och använda den domänen för uppföljande länkar som användaren använde för att få tillgång till din blogg.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index-fil');
 @define('INSTALL_INDEXFILE_DESC', 'Namnet på din index-fil för Serendipity');
 

--- a/lang/serendipity_lang_sk.inc.php
+++ b/lang/serendipity_lang_sk.inc.php
@@ -690,6 +690,8 @@ $i18n_filename_to = array (
 @define('INSTALL_URL_DESC', 'Základná URL Va¹ej in¹talácie Serendipity');
 @define('INSTALL_AUTODETECT_URL', 'Autodetekcia pou¾itej HTTP adresy na serveri');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Pri voµbe "Áno" bude Serendipity predpoklada», ¾e HTTP adresa pou¾itá náv¹tevníkom, je Va¹é základné nastavenie URL. Zapnutie umo¾ní pou¾íváníe rôznych domén k prístupu na Va¹e stránky, a pou¾itie téjto jednej domény pre v¹etky odkazy na sledovánie zmien na stránkách.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Indexový súbor');
 @define('INSTALL_INDEXFILE_DESC', 'Názov súboru pou¾itého ako index');
 

--- a/lang/serendipity_lang_ta.inc.php
+++ b/lang/serendipity_lang_ta.inc.php
@@ -677,6 +677,8 @@
 @define('INSTALL_URL_DESC', 'இந்த வலைக்குறிப்பின் வலைமுகவரி');
 @define('INSTALL_AUTODETECT_URL', 'Autodetect used HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', 'If set to "true", Serendipity will ensure that the HTTP Host which was used by your visitor is used as your BaseURL setting. Enabling this will let you be able to use multiple domain names for your Serendipity Blog, and use the domain for all follow-up links which the user used to access your blog.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'வலைக்குறிப்பின் முதற்பக்க மென்பொருள்');
 @define('INSTALL_INDEXFILE_DESC', 'வலைக்குறிப்பின் முதற்பக்க மென்பொருளின் பெயர்');
 

--- a/lang/serendipity_lang_tn.inc.php
+++ b/lang/serendipity_lang_tn.inc.php
@@ -680,6 +680,8 @@ $i18n_unknown = 'tw';
 @define('INSTALL_URL_DESC', '您的 Serendipity 安裝的基本 URL');
 @define('INSTALL_AUTODETECT_URL', '自動偵測 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果設定為 "true"，Serendipity 會確定讀者的 HTTP Host 跟您的基本 URL 設定相同。開啟這項功能可以允許您使用多數的網域名稱給您的網誌，和使用這個網域給跟進的連結。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 檔案');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipity 的 index 檔案');
 

--- a/lang/serendipity_lang_tr.inc.php
+++ b/lang/serendipity_lang_tr.inc.php
@@ -679,6 +679,8 @@
 @define('INSTALL_URL_DESC', 'Serendipity kurulumunuz için Temel URL adresi ');
 @define('INSTALL_AUTODETECT_URL', 'HTTP-Host Servisini otomatik belirle');
 @define('INSTALL_AUTODETECT_URL_DESC', 'Eğer "true" olarak seçilirse, Serendipity ziyaretçilerin HTTP Host adresini sizin BaseURL ayarlarınıza göre kesin olarak belirleyebilecek.Bu seçenek açık olursa çoklu domain kullanma imkanına da sahip olursunuz, ve tüm izleyen bağlantılarda hangi kullanıcı hangi site bölümünüze erişmek istiyorsa erişebilir.');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index dosyası');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipity index dosyasının adı');
 

--- a/lang/serendipity_lang_tw.inc.php
+++ b/lang/serendipity_lang_tw.inc.php
@@ -680,6 +680,8 @@ $i18n_unknown = 'tw';
 @define('INSTALL_URL_DESC', '您的 Serendipity 安裝的基本 URL');
 @define('INSTALL_AUTODETECT_URL', '自動偵測 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果設定為 "true"，Serendipity 會確定讀者的 HTTP Host 跟您的基本 URL 設定相同。開啟這項功能可以允許您使用多數的網域名稱給您的網誌，和使用這個網域給跟進的連結。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 檔案');
 @define('INSTALL_INDEXFILE_DESC', 'Serendipity 的 index 檔案');
 

--- a/lang/serendipity_lang_zh.inc.php
+++ b/lang/serendipity_lang_zh.inc.php
@@ -680,6 +680,8 @@
 @define('INSTALL_URL_DESC', '系统安装的基本地址');
 @define('INSTALL_AUTODETECT_URL', '自动检测 HTTP-Host');
 @define('INSTALL_AUTODETECT_URL_DESC', '如果设定为 "true"，HTTP Host 跟基本的地址设定相同。开启这项功能可以允许你使用多个的域名的日志和使用这个日志域名连接。');
+@define('INSTALL_AUTODETECT_VALID_HOSTS', 'Valid autodetected HTTP-Hosts');
+@define('INSTALL_AUTODETECT_VALID_HOSTS_DESC', 'Set this to a comma separated list of allowed HTTP Hosts. Only those will be used for the autodetected base URL. This is a security measure for server setups that accept arbitrary HTTP host headers.');
 @define('INSTALL_INDEXFILE', 'Index 文件');
 @define('INSTALL_INDEXFILE_DESC', '系统的 index 文件');
 

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -351,9 +351,37 @@ serendipity_initLog();
 if ( (isset($serendipity['autodetect_baseURL']) && serendipity_db_bool($serendipity['autodetect_baseURL'])) ||
      (isset($serendipity['embed']) && serendipity_db_bool($serendipity['embed'])) ) {
     $constructedBaseURL = 'http' . (S9Y_IS_HTTPS_SERVER ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] . (!strstr($_SERVER['HTTP_HOST'], ':') && !empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' && $_SERVER['SERVER_PORT'] != '443' ? ':' . $_SERVER['SERVER_PORT'] : '') . $serendipity['serendipityHTTPPath'];
+
+    // The autodetected baseURL can be manipulated in some server setups as $_SERVER['HTTP_HOST'] is
+    // choosable by the client. We now do some checks to limit this vector as much as possible.
+     $baseURLChecked = false;
+    
+    // First, check that the constructed URL looks at least vaguely correct
     $constructedBaseURL = filter_var($constructedBaseURL, FILTER_VALIDATE_URL);
     if ($constructedBaseURL) {
+        if (isset($serendipity['validBaseHosts']) && $serendipity['validBaseHosts']) {
+            // Second, only go forward if the HOST is on the list. This we can only do if the user
+            // configured that list.
+            $autoHost = parse_url($constructedBaseURL, PHP_URL_HOST);
+            $validHosts = explode(',', $serendipity['validBaseHosts']);
+            if (in_array($autoHost,  $validHosts)) {
+                $baseURLChecked = true;
+            }
+        } else {
+            $baseURLChecked = true;
+        }
+    }
+    if ($baseURLChecked) {
         $serendipity['baseURL'] = $constructedBaseURL;
+    } else {
+        if (isset($_SESSION['serendipityAuthorid'])) {
+            echo "Careful: Invalid base URL. Logged out users would be blocked, change the configuration.";
+        } else {
+            echo "Invalid base URL";
+            header("HTTP/1.0 401 Unauthorized");
+            header("Status: 401 Unauthorized");
+            exit;
+        }
     }
 }
 

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -361,10 +361,10 @@ if ( (isset($serendipity['autodetect_baseURL']) && serendipity_db_bool($serendip
     if ($constructedBaseURL) {
         if (isset($serendipity['validBaseHosts']) && $serendipity['validBaseHosts']) {
             // Second, only go forward if the HOST is on the list. This we can only do if the user
-            // configured that list.
-            $autoHost = parse_url($constructedBaseURL, PHP_URL_HOST);
-            $validHosts = explode(',', $serendipity['validBaseHosts']);
-            if (in_array($autoHost,  $validHosts)) {
+            // configured that list. Lowercase everything since URLs are case insensitive
+            $autoHost = strtolower(parse_url($constructedBaseURL, PHP_URL_HOST));
+            $validHosts = array_map('strtolower', explode(',', $serendipity['validBaseHosts']));
+            if (in_array($autoHost,  $validHosts, true)) {
                 $baseURLChecked = true;
             }
         } else {

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -374,14 +374,7 @@ if ( (isset($serendipity['autodetect_baseURL']) && serendipity_db_bool($serendip
     if ($baseURLChecked) {
         $serendipity['baseURL'] = $constructedBaseURL;
     } else {
-        if (isset($_SESSION['serendipityAuthorid'])) {
-            echo "Careful: Invalid base URL. Logged out users would be blocked, change the configuration.";
-        } else {
-            echo "Invalid base URL";
-            header("HTTP/1.0 401 Unauthorized");
-            header("Status: 401 Unauthorized");
-            exit;
-        }
+        echo "Careful: Invalid base URL.";
     }
 }
 

--- a/serendipity_config.inc.php
+++ b/serendipity_config.inc.php
@@ -350,7 +350,11 @@ serendipity_initLog();
 
 if ( (isset($serendipity['autodetect_baseURL']) && serendipity_db_bool($serendipity['autodetect_baseURL'])) ||
      (isset($serendipity['embed']) && serendipity_db_bool($serendipity['embed'])) ) {
-    $serendipity['baseURL'] = 'http' . (S9Y_IS_HTTPS_SERVER ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] . (!strstr($_SERVER['HTTP_HOST'], ':') && !empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' && $_SERVER['SERVER_PORT'] != '443' ? ':' . $_SERVER['SERVER_PORT'] : '') . $serendipity['serendipityHTTPPath'];
+    $constructedBaseURL = 'http' . (S9Y_IS_HTTPS_SERVER ? 's' : '') . '://' . $_SERVER['HTTP_HOST'] . (!strstr($_SERVER['HTTP_HOST'], ':') && !empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' && $_SERVER['SERVER_PORT'] != '443' ? ':' . $_SERVER['SERVER_PORT'] : '') . $serendipity['serendipityHTTPPath'];
+    $constructedBaseURL = filter_var($constructedBaseURL, FILTER_VALIDATE_URL);
+    if ($constructedBaseURL) {
+        $serendipity['baseURL'] = $constructedBaseURL;
+    }
 }
 
 // If a user is logged in, fetch his preferences. He possibly wants to have a different language


### PR DESCRIPTION
Give an option to secure the http host detection when using the autodetect base URL mode.

Thanks to [@mabjr33 ](https://github.com/mabjr33) for the suggestion.