### PR TITLE
Update comments.inc.php for compatibility with PHP 8.3

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.7-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Fix division by zero error when accessing all PHP comments on PHP 8
+     (thanks to @qbi)
+
 Version 2.6.0 (April 10th, 2026)
 ------------------------------------------------------------------------
 

--- a/include/admin/comments.inc.php
+++ b/include/admin/comments.inc.php
@@ -6,7 +6,11 @@ if (IN_serendipity !== true) {
 
 $data = array();
 
-$commentsPerPage = (int)(!empty($serendipity['GET']['filter']['perpage']) ? $serendipity['GET']['filter']['perpage'] : 10);
+$commentsPerPage = !empty($serendipity['GET']['filter']['perpage']) ? $serendipity['GET']['filter']['perpage'] : 10;
+if ($commentsPerPage != COMMENTS_FILTER_ALL) {
+    $commentsPerPage = (int)($commentsPerPage);
+}
+
 $summaryLength = 200;
 
 $errormsg = array();
@@ -257,7 +261,7 @@ $searchString .= '&amp;' . serendipity_setFormToken('url');
 $sql = serendipity_db_query("SELECT COUNT(*) AS total FROM {$serendipity['dbPrefix']}comments c WHERE 1 = 1 " . ($c_type !== null ? " AND c.type = '$c_type' " : '') . $and, true);
 
 $totalComments = $sql['total'];
-$pages = ($commentsPerPage == COMMENTS_FILTER_ALL ? 1 : ceil($totalComments/(int)$commentsPerPage));
+$pages = ($commentsPerPage === COMMENTS_FILTER_ALL ? 1 : ceil($totalComments/(int)$commentsPerPage));
 if (isset($serendipity['GET']['page'])) {
     $page = (int)$serendipity['GET']['page'];
 } else {
@@ -271,7 +275,7 @@ $linkPrevious = 'serendipity_admin.php?serendipity[adminModule]=comments&amp;ser
 $linkNext     = 'serendipity_admin.php?serendipity[adminModule]=comments&amp;serendipity[page]='. ($page+1) . $searchString;
 $filter_vals  = array(10, 20, 50, COMMENTS_FILTER_ALL);
 
-if ($commentsPerPage == COMMENTS_FILTER_ALL) {
+if ($commentsPerPage === COMMENTS_FILTER_ALL) {
     $limit = '';
 } else {
     $limit = serendipity_db_limit_sql(serendipity_db_limit(($page-1)*(int)$commentsPerPage, (int)$commentsPerPage));


### PR DESCRIPTION
When you want to access all comments, S9Y runs into an HTTP 500: `PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero` in line 260.

The comparison of strings and integers has changed in PHP 8. See https://www.php.net/manual/en/migration80.incompatible.php

Previously the comparison in line 260 was `0 == 'all'` -> true. Whith the changes the comparison now is `0 == 'all'` -> false. Which leads to the above mentioned error message.

I changed the code in a way that `$commentsPerPage` has either an interger or`COMMENTS_FILTER_ALL` as value and the comparison now checks type and value. So in the case of all comments the comparison is `'all' === 'all` -> true.

This should fix the code.