### PR TITLE
Add cleanCache() calls where they were missing

### DIFF
--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,6 +1,9 @@
 Version 2.7-alpha1 ()
 ------------------------------------------------------------------------
 
+   * Add cleanCache() on comment editing, deletion and category changes
+     (thanks to @fasterit/DLange)
+
    * Fix division by zero error when accessing all PHP comments on PHP 8
      (thanks to @qbi)
      

--- a/include/admin/comments.inc.php
+++ b/include/admin/comments.inc.php
@@ -48,6 +48,7 @@ if (isset($serendipity['GET']['adminAction']) && $serendipity['GET']['adminActio
                   entry_id = " . (int)$serendipity['POST']['entry_id'];
     serendipity_db_query($sql);
     serendipity_plugin_api::hook_event('backend_updatecomment', $serendipity['POST'], $serendipity['GET']['id']);
+    serendipity_cleanCache();
     $msg[] = COMMENT_EDITED;
 }
 

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -1078,6 +1078,7 @@ function serendipity_addCategory($name, $desc, $authorid, $icon, $parentid) {
 
     serendipity_plugin_api::hook_event('multilingual_strip_langs',$data, array('category_name','category_description'));
     serendipity_insertPermalink($data, 'category');
+    serendipity_cleanCache();
     return $cid;
 }
 
@@ -1120,6 +1121,7 @@ function serendipity_updateCategory($cid, $name, $desc, $authorid, $icon, $paren
 
     serendipity_plugin_api::hook_event('multilingual_strip_langs',$data, array('category_name','category_description'));
     serendipity_updatePermalink($data, 'category');
+    serendipity_cleanCache();
 }
 
 /**

--- a/include/functions_comments.inc.php
+++ b/include/functions_comments.inc.php
@@ -584,6 +584,7 @@ function serendipity_deleteComment($id, $entry_id, $type='comments', $token=fals
         $addData = array('cid' => $id, 'entry_id' => $entry_id);
         serendipity_plugin_api::hook_event('backend_deletecomment', $sql, $addData);
 
+        serendipity_cleanCache();
         return true;
     } else {
         return false;
@@ -609,6 +610,7 @@ function serendipity_allowCommentsToggle($entry_id, $switch = 'disable') {
 
         $query = "UPDATE {$serendipity['dbPrefix']}entries SET allow_comments = '" . ($switch == 'disable' ? 'false' : 'true') . "' WHERE id = '". (int)$entry_id ."' $admin";
         serendipity_db_query($query);
+        serendipity_cleanCache();
         if (serendipity_isResponseClean($_SERVER['HTTP_REFERER'])) {
             header('Status: 302 Found');
             header('Location: '. $_SERVER['HTTP_REFERER']);

--- a/include/functions_entries.inc.php
+++ b/include/functions_entries.inc.php
@@ -23,6 +23,7 @@ function serendipity_deleteCategory($category_range, $admin_category) {
 
     serendipity_plugin_api::hook_event('backend_category_delete', $category_range);
 
+    serendipity_cleanCache();
     return serendipity_db_query("DELETE FROM {$serendipity['dbPrefix']}category WHERE category_left BETWEEN {$category_range} {$admin_category}");
 }
 


### PR DESCRIPTION
Prevent producting outdated cache entries after these functions:
* Comment edited via admin interface
* Comment deletion
* Comment form visibility toggle
* Adding, Updating or Deleting a category