### PR TITLE
support SQL execution after aquiring a new database connection

### DIFF
--- a/include/db/pdo-sqlite.inc.php
+++ b/include/db/pdo-sqlite.inc.php
@@ -104,6 +104,13 @@ function serendipity_db_connect() {
                                  'sqlite:' . (defined('S9Y_DATA_PATH') ? S9Y_DATA_PATH : $serendipity['serendipityPath']) . $serendipity['dbName'] . '.db'
                              );
 
+    // Handle additional connection setup if set
+    if (isset($serendipity['sqlitePragmas'])) {
+        foreach($serendipity['sqlitePragmas'] as $sql) {
+            serendipity_db_query($sql);
+        }
+    }
+
     return $serendipity['dbConn'];
 }
 

--- a/include/db/sqlite.inc.php
+++ b/include/db/sqlite.inc.php
@@ -57,6 +57,13 @@ function serendipity_db_connect()
         $serendipity['dbConn'] = $function($serendipity['dbName'] . '.db');
     }
 
+    // Handle additional connection setup if set
+    if (isset($serendipity['sqlitePragmas'])) {
+        foreach($serendipity['sqlitePragmas'] as $sql) {
+            serendipity_db_query($sql);
+        }
+    }
+
     return $serendipity['dbConn'];
 }
 

--- a/include/db/sqlite3.inc.php
+++ b/include/db/sqlite3.inc.php
@@ -53,6 +53,13 @@ function serendipity_db_connect()
     // SQLite3 doesn't support persistent connections
     $serendipity['dbConn'] = sqlite3_open((defined('S9Y_DATA_PATH') ? S9Y_DATA_PATH : $serendipity['serendipityPath']) . $serendipity['dbName'] . '.db');
 
+    // Handle additional connection setup if set
+    if (isset($serendipity['sqlitePragmas'])) {
+        foreach($serendipity['sqlitePragmas'] as $sql) {
+            serendipity_db_query($sql);
+        }
+    }
+    
     return $serendipity['dbConn'];
 }
 

--- a/include/db/sqlite3oo.inc.php
+++ b/include/db/sqlite3oo.inc.php
@@ -53,6 +53,13 @@ function serendipity_db_connect()
     // SQLite3 doesn't support persistent connections
     $serendipity['dbConn'] = new SQLite3((defined('S9Y_DATA_PATH') ? S9Y_DATA_PATH : $serendipity['serendipityPath']) . $serendipity['dbName'] . '.db');
 
+    // Handle additional connection setup if set
+    if (isset($serendipity['sqlitePragmas'])) {
+        foreach($serendipity['sqlitePragmas'] as $sql) {
+            serendipity_db_query($sql);
+        }
+    }
+
     return $serendipity['dbConn'];
 }
 


### PR DESCRIPTION
I have switched my s9y instance from MySql/MariaDB to SQLite in 2024 and while doing the update to s9y 2.6.0 I've just stumbled about a local patch with the notice "upstream this". Here it is:

I've looked a bit into tuning the SQLite database access simply by measuring page load times. With some simple changes I got a measurable speedups. Database tuning in SQLite is done by sending some `PRAGMA` SQL commands after the connection to the database was is aquired.  
Because s9y has no way to do this that I know of, I've added a new global configuration variable `dbSqlOnNewConnection` that makes it possible to execute some SQL statements automatically on every new database connection.  The variable is optional (so new changes neccessary on existing installations) and accepts either a single SQL command as a String or multiple commands as an Array of Strings.  
(Somehow I was not able to combine multiple `PRAGMA`s separated by `;` into a single SQL statement to be executed, so I added the array form as an alternative.)

This is the configuration I currently use (excerpt from my `serendipity_config_local.inc.php`)  – while this might not be fit for copy and paste because it is tuned to my database size and setup, it shows how this is supposed to work:

```php
    // set DB connection parameters after connect
    $serendipity['dbSqlOnNewConnection'] = [
        'PRAGMA journal_mode = WAL;',
        'PRAGMA synchronous  = FULL;',          // eigentlich ON, aber zu wenig Schreibzugriffe, dann lieber richtig
        'PRAGMA journal_size_limit = 2097152;', // 2MB, die ganze DB ist ja keine 16 MB groß...
        'PRAGMA mmap_size    = 16777216;',      // 16MB; bisher war die ganze DB zwischen 9 und 13 MB groß, sollte reichen
        'PRAGMA cache_size   = 512;',           // 512x4k -> 2MB, das ist ziemlich genau der Default von -2000 = 2000k :)
        'PRAGMA busy_timeout = 10000;',         // max. 10 Sekunden auf Connection warten (intern mit exponentiellem Backoff)
        # 'PRAGMA foreign_keys = ON;'            // FIXME: es gibt aktuell keine Fremdbeziehungen, liegt das am DB-Import oder macht s9y das immer ohne?
    ];
    /*
      defaults on my system:
      journal_mode = delete
      synchronous = 2
      journal_size_limit = -1
      mmap_size = 0
      cache_size = -2000
      busy_timeout = 60000
      foreign_keys = 0
    */

```

For the available `PRAGMA`s see: https://sqlite.org/pragma.html

I think this should at least be useful on every installation with the SQLite database backend to be able to tune the database access, but it might also come in handy with other databases or for some completely different purposes.

(I've also added some lines of code to the admin interface to show the current SQLite `PRAGMA` settings, but it's simply thrown into the category page and not properly formatted. I'll omit this for now.)

If you find this now configuration variable useful, please accept this pull request.
It's rebased against the current master branch and should apply without problems.