### PR TITLE
Escape the host in the RSS self link

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -251,7 +251,7 @@ $metadata['template_file'] = 'feed_' . $file_version . '.tpl';
 serendipity_smarty_init();
 serendipity_plugin_api::hook_event('frontend_rss', $metadata);
 
-$self_url = ($_SERVER['HTTPS'] == 'on' ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . serendipity_specialchars($_SERVER['REQUEST_URI']);
+$self_url = ($_SERVER['HTTPS'] == 'on' ? 'https://' : 'http://') . serendipity_specialchars($_SERVER['HTTP_HOST']) . serendipity_specialchars($_SERVER['REQUEST_URI']);
 if (!is_array($entries)) {
     $entries = array();
 }


### PR DESCRIPTION
Following up on GHSA-9r48-m5jc-v6hj as ordinary hardening, per @onli.

`rss.php:254` builds `$self_url` and it is rendered into the Atom feed as the `rel="self"` href in `templates/default/feed_atom1.0.tpl` and `templates/2k11/feed_atom1.0.tpl`. `REQUEST_URI` on that line already goes through `serendipity_specialchars()`. `HTTP_HOST` does not, so the raw header value lands inside an XML attribute. There is no Smarty autoescape configured, so nothing catches it downstream.

One correction to what I wrote in the advisory thread, since it was too generous to the current state. I said Apache and nginx both reject those characters. That is right for Apache from 2.4.24 with the default `HttpProtocolOptions Strict`, and right for nginx only from **1.29.4** (2025-12-09), when host validation was rewritten to follow RFC 3986. On 1.29.3 and earlier the check is a blocklist that rejects `/`, control characters and anything at or below 0x20, and accepts `"`, `<` and `>`. That includes the current 1.28.x stable branch and the builds in Debian, Ubuntu LTS and RHEL.

Checked against nginx 1.28.0 built from the nginx.org tarball in front of PHP-FPM 8.5.10:

```
Host: evil.com"><b>     -> 200, HTTP_HOST=[evil.com"><b>]
Host: evil.com foo      -> 400
Host: evil.com/x        -> 400
```

So the quote does reach PHP on a lot of live installs. No space and no forward slash, which limits what can be written, but enough to close the attribute.

I am not claiming this is exploitable and I would not file it as a security issue. The feed goes out with `Cache-Control: no-store` and a session cookie, so there is no shared-cache route, and a visitor browser only ever sends the site its own host. It stays self-inflicted, which is exactly the point you made on the advisory. This is just unescaped output that the same line already handles correctly one call along.

The change matches the existing style rather than introducing anything new:

```php
serendipity_specialchars($_SERVER[HTTP_HOST])
```

`php -l` clean. A legitimate host contains no characters that `serendipity_specialchars()` alters, so well-formed requests produce byte-identical output.