### PR TITLE
update release script

### DIFF
--- a/bundled-libs/create_release.sh
+++ b/bundled-libs/create_release.sh
@@ -89,8 +89,12 @@ else
             echo "   - $2/bundled-libs/create_release.sh [766]"
             chmod 766 "$2/bundled-libs/create_release.sh"
             
+            echo "   - $2/.github [remove]"
+            rm -rf "$2/.github"
+
             echo "   - $2/tests [remove]"
             rm -rf "$2/tests"
+
             echo "    [DONE]"
             echo ""
 

--- a/bundled-libs/create_release.sh
+++ b/bundled-libs/create_release.sh
@@ -86,8 +86,8 @@ else
             echo "   - $2/upgrade.sh [744]"
             chmod 744 "$2/upgrade.sh"
 
-            echo "   - $2/bundled-libs/create_release.sh [766]"
-            chmod 766 "$2/bundled-libs/create_release.sh"
+            echo "   - $2/bundled-libs/create_release.sh [remove]"
+            rm -f "$2/bundled-libs/create_release.sh"
             
             echo "   - $2/.github [remove]"
             rm -rf "$2/.github"

--- a/bundled-libs/create_release.sh
+++ b/bundled-libs/create_release.sh
@@ -112,19 +112,8 @@ else
                 fi
             fi
             echo ""
-        echo "7. Altering CVS to be useful for anonymous users..."
-            echo "   - Removing CVS branch tag, so that a user can upgrade to latest CVS"
-            find "$2" -type f -name Tag -exec rm {} \;
-            echo "       [DONE]"
 
-            echo "   - Inserting ANONYMOUS user instead of Developer account"
-            for i in `find $2 -type f -name Root` ; do
-                echo ':pserver:anonymous@cvs.sf.net:/cvsroot/php-blog' > $i;
-            done
-            echo "       [DONE]"
-            echo ""
-
-        echo "8. Creating .tgz file $1"
+        echo "7. Creating .tgz file $1"
             tar --owner=$3 --group=$4 -czf "$1" "$2"
             echo "    [DONE]"
             echo ""


### PR DESCRIPTION
Please see issue #978 for the background.

This PR tweaks various things about the `bundled-libs/create_release.sh` script:
- Remove .github/ directory from release archive
- Don't include create_release.sh in the release archive
- Remove special CVS handling from create_release.sh
- Fix ShellCheck findings in create_release.sh
- Fix directory check in create_release.sh
- Abort create_release.sh when a .git directory is detected

Please see the individual commits for further information.